### PR TITLE
fix: text cutoff in bounty info section

### DIFF
--- a/src/components/bounty/BountyInfo.tsx
+++ b/src/components/bounty/BountyInfo.tsx
@@ -79,7 +79,7 @@ const BountyInfo = ({ bountyId }: { bountyId: string }) => {
   return (
     <>
     <div className="flex pt-20 flex-col  justify-between lg:flex-row">
-      <div className="flex flex-col  lg:max-w-[50%]">
+      <div className="flex flex-col  lg:max-w-[50%] break-all">
         <p className=" text-2xl lg:text-4xl text-bold">{bountyData?.name}</p>
         <p className="mt-5">{bountyData?.description}</p>
         <p className="mt-5">Bounty issuer: {bountyData?.issuerDegenOrEnsName || bountyData?.issuer}</p>


### PR DESCRIPTION
See issue https://github.com/picsoritdidnthappen/poidh-app/issues/49 and issue https://github.com/picsoritdidnthappen/poidh-app/issues/108

![image](https://github.com/picsoritdidnthappen/poidh-app/assets/169092153/a44aad69-5328-40de-8683-1b3219666858)
