### PR TITLE
fix: Prevent text case manipulation in ProofItem by applying inline styles

### DIFF
--- a/src/components/bounty/BountyInfo.tsx
+++ b/src/components/bounty/BountyInfo.tsx
@@ -79,8 +79,8 @@ const BountyInfo = ({ bountyId }: { bountyId: string }) => {
     <>
       <div className='flex pt-20 flex-col  justify-between lg:flex-row'>
         <div className='flex flex-col  lg:max-w-[50%] break-all'>
-          <p className=' text-2xl lg:text-4xl text-bold'>{bountyData?.name}</p>
-          <p className='mt-5'>{bountyData?.description}</p>
+          <p className='no-transform text-2xl lg:text-4xl text-bold'>{bountyData?.name}</p>
+          <p className='no-transform mt-5'>{bountyData?.description}</p>
           <p className='mt-5'>
             Bounty issuer:{' '}
             {bountyData?.issuerDegenOrEnsName || bountyData?.issuer}

--- a/src/components/bounty/ProofItem.tsx
+++ b/src/components/bounty/ProofItem.tsx
@@ -141,8 +141,8 @@ const ProofItem: React.FC<ProofItemProps> = ({
       ></div>
       <div className='p-3'>
         <div className='flex flex-col'>
-          <p className=''>{title}</p>
-          <p className='break-all	'>{description}</p>
+          <p className='' style={{ textTransform: 'none' }}>{title}</p>
+          <p className='break-all' style={{ textTransform: 'none' }}>{description}</p>
         </div>
         <div className='mt-2 py-2 flex flex-row justify-between text-sm border-t border-dashed'>
           <span className=''>issuer</span>

--- a/src/components/bounty/ProofItem.tsx
+++ b/src/components/bounty/ProofItem.tsx
@@ -141,8 +141,8 @@ const ProofItem: React.FC<ProofItemProps> = ({
       ></div>
       <div className='p-3'>
         <div className='flex flex-col'>
-          <p className='' style={{ textTransform: 'none' }}>{title}</p>
-          <p className='break-all' style={{ textTransform: 'none' }}>{description}</p>
+          <p className='no-transform'>{title}</p>
+          <p className='no-transform break-all	'>{description}</p>
         </div>
         <div className='mt-2 py-2 flex flex-row justify-between text-sm border-t border-dashed'>
           <span className=''>issuer</span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -123,6 +123,10 @@
   .animated-underline:focus-visible {
     background-size: 0 2px, 100% 2px;
   }
+
+  .no-transform {
+    text-transform: none;
+  }
 }
 
 body {


### PR DESCRIPTION
**Issue:**

The text case of titles and descriptions in the ProofItem component was being affected by styles defined in global.css.

**Fix:**

This pull request applies inline styles to the `<p>` elements within ProofItem, setting `text-transform: none` to prevent case manipulation.

**Requesting Review:**

Please review the changes and provide feedback.