### PR TITLE
Ie2173/normal case proof description

### DIFF
--- a/src/components/bounty/BountyInfo.tsx
+++ b/src/components/bounty/BountyInfo.tsx
@@ -73,8 +73,10 @@ const BountyInfo = ({ bountyId }: { bountyId: string }) => {
     <>
       <div className='flex pt-20 flex-col  justify-between lg:flex-row'>
         <div className='flex flex-col  lg:max-w-[50%]'>
-          <p className=' text-2xl lg:text-4xl text-bold'>{bountyData?.name}</p>
-          <p className='mt-5'>
+          <p className=' text-2xl lg:text-4xl text-bold normal-case'>
+            {bountyData?.name}
+          </p>
+          <p className='mt-5 normal-case'>
             {bountyData?.description.split(' ').map((word, i) => {
               if (word.length > 40) {
                 return (

--- a/src/components/bounty/ProofItem.tsx
+++ b/src/components/bounty/ProofItem.tsx
@@ -153,7 +153,7 @@ const ProofItem: React.FC<ProofItemProps> = ({
       <div className='p-3'>
         <div className='flex flex-col'>
           <p className=''>{title}</p>
-          <p className='break-all	'>{description}</p>
+          <p className='break-all normal-case	'>{description}</p>
         </div>
         <div className='mt-2 py-2 flex flex-row justify-between text-sm border-t border-dashed'>
           <span className=''>issuer</span>

--- a/src/components/bounty/ProofItem.tsx
+++ b/src/components/bounty/ProofItem.tsx
@@ -152,7 +152,7 @@ const ProofItem: React.FC<ProofItemProps> = ({
       ></div>
       <div className='p-3'>
         <div className='flex flex-col'>
-          <p className=''>{title}</p>
+          <p className='normal-case'>{title}</p>
           <p className='break-all normal-case	'>{description}</p>
         </div>
         <div className='mt-2 py-2 flex flex-row justify-between text-sm border-t border-dashed'>

--- a/src/components/ui/BountyItem.tsx
+++ b/src/components/ui/BountyItem.tsx
@@ -30,8 +30,8 @@ const BountyItem: React.FC<BountyItemProps> = ({
     <>
       <div className='relative p-[2px] h-full  rounded-xl'>
         <div className='p-5 flex flex-col justify-between relative z-20 h-full lg:col-span-4'>
-          <div className='z-[-1] absolute w-full h-full left-0 top-0 borderBox rounded-[6px]  bg-whiteblue normal-case '></div>
-          <h3>{title}</h3>
+          <div className='z-[-1] absolute w-full h-full left-0 top-0 borderBox rounded-[6px]  bg-whiteblue'></div>
+          <h3 className='normal-case'>{title}</h3>
           <p className='my-5 break-all normal-case	 '>{shortDescription}</p>
 
           <div className='flex items-end justify-between mt-5'>

--- a/src/components/ui/BountyItem.tsx
+++ b/src/components/ui/BountyItem.tsx
@@ -30,9 +30,9 @@ const BountyItem: React.FC<BountyItemProps> = ({
     <>
       <div className='relative p-[2px] h-full  rounded-xl'>
         <div className='p-5 flex flex-col justify-between relative z-20 h-full lg:col-span-4'>
-          <div className='z-[-1] absolute w-full h-full left-0 top-0 borderBox rounded-[6px]  bg-whiteblue '></div>
+          <div className='z-[-1] absolute w-full h-full left-0 top-0 borderBox rounded-[6px]  bg-whiteblue normal-case '></div>
           <h3>{title}</h3>
-          <p className='my-5 break-all	 '>{shortDescription}</p>
+          <p className='my-5 break-all normal-case	 '>{shortDescription}</p>
 
           <div className='flex items-end justify-between mt-5'>
             <div className='flex gap-2 items-center'>


### PR DESCRIPTION
**Description**
- **Issue:** [#114](https://github.com/picsoritdidnthappen/poidh-app/issues/114)
- **Summary:** The issue is caused due to a global CSS variable which defaults all text to lower case.  To Fix this I changed the CSS via tailwind for effected sections to allow for titles and descriptions to be normal cased.   

**Changes Made**
- added `normal case` to p html tag on line 155 & 156 on `ProofItem.tsx` .
- added `normal case` to p html tag on line 76 & 79 on `ProofItem.tsx` .
- added `normal case` to p html tag on line 34 & 35 on `BountyItem.tsx` .

**Verification**
- Manually tested the Bounty Cards and Bounty Pages to ensure normal casing.

PICS OR IT DIDNT HAPPEN: 
<img width="1418" alt="Screenshot 2024-05-31 at 10 54 36" src="https://github.com/picsoritdidnthappen/poidh-app/assets/67490985/21c60f79-2655-4a86-9c30-d12c782aa2ca">
<img width="1418" alt="Screenshot 2024-05-31 at 12 10 49" src="https://github.com/picsoritdidnthappen/poidh-app/assets/67490985/7fdc74d2-fc1b-49da-9886-8bc5553a2628">
<img width="1418" alt="Screenshot 2024-05-31 at 11 50 22" src="https://github.com/picsoritdidnthappen/poidh-app/assets/67490985/8df36b3c-c390-415c-9d85-1985295fc8b1">


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

**Additional Context**
N/A
