### PR TITLE
Enable Dynamic "Connect Only" Mode

### DIFF
--- a/src/app/context/ContextProvider.tsx
+++ b/src/app/context/ContextProvider.tsx
@@ -242,6 +242,7 @@ const ContextProvider: React.FC<ContextProviderProps> = ({ children }) => {
         networkValidationMode: 'always',
         walletConnectorExtensions: [EthersExtension],
         cssOverrides,
+        initialAuthenticationMode: 'connect-only',
       }}
     >
       {children}


### PR DESCRIPTION
**Description**
- **Issue:** [#132](https://github.com/picsoritdidnthappen/poidh-app/issues/132)
- **Summary:**  Allows users to bypass needing to sign in/verify signature/ via their web3 wallet in the @dynamic-labs dynamic context provider. By adding the flag in settings of the provider via the initialAuthenticationMode flag, this allows the user to not need to sign in when initially connecting or when their metamask session has expired.  This is according to the [dynamic labs documentation](https://docs.dynamic.xyz/wallets/advanced-wallets/connect).

**Changes Made**
- added the flag ``initialAuthenticationMode: 'connect-only', to file `ContextProvider.tsx`.


**Verification**
- Manually tested the login functionality with metamask upon first entering the site, letting metamask expire, disconnecting and reconnecting to a site and connecting via a new wallet account. 

**PICS OR IT DIDNT HAPPEN**
Can not provide a video.  Can submit proof that it works if need be, but mr or ms or mrs reviewer, please try this out on your system first to make sure its not just only working on my system. 

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

**Additional Context**
- If necessary, I can use use other browser injected wallets to test if functionality still works, since I only tested with metamask 
