### PR TITLE
remove connect only feature to wallet

### DIFF
--- a/src/app/context/ContextProvider.tsx
+++ b/src/app/context/ContextProvider.tsx
@@ -242,7 +242,6 @@ const ContextProvider: React.FC<ContextProviderProps> = ({ children }) => {
         networkValidationMode: 'always',
         walletConnectorExtensions: [EthersExtension],
         cssOverrides,
-        initialAuthenticationMode: 'connect-only',
       }}
     >
       {children}


### PR DESCRIPTION
This Removes the Feature to connect only with the dynamic wallet.  This will revert the code to before this was implemented in PR #139.