### PR TITLE
fix: split words with regex whitespace instead of literal

### DIFF
--- a/src/components/bounty/BountyInfo.tsx
+++ b/src/components/bounty/BountyInfo.tsx
@@ -97,7 +97,7 @@ const BountyInfo = ({ bountyId }: { bountyId: string }) => {
             {bountyData?.name}
           </p>
           <p className='mt-5'>
-            {bountyData?.description.split(' ').map((word, i) => {
+            {bountyData?.description.split(/\s+/).map((word, i) => {
               if (word.length > 40) {
                 return (
                   <span className='break-all' key={i}>

--- a/src/components/bounty/BountyInfo.tsx
+++ b/src/components/bounty/BountyInfo.tsx
@@ -97,7 +97,7 @@ const BountyInfo = ({ bountyId }: { bountyId: string }) => {
             {bountyData?.name}
           </p>
           <p className='mt-5'>
-            {bountyData?.description.split(/\s+/).map((word, i) => {
+            {bountyData?.description.split(/\s/).map((word, i) => {
               if (word.length > 40) {
                 return (
                   <span className='break-all' key={i}>


### PR DESCRIPTION
Fix split by whitespace not working in certain cases, see example

<img width="412" alt="image" src="https://github.com/picsoritdidnthappen/poidh-app/assets/169092153/7d387505-4456-4af1-8203-bdb588f49b0b">
