### PR TITLE
Refresh bounty page after new claim is submitted

### DIFF
--- a/src/app/context/web3.tsx
+++ b/src/app/context/web3.tsx
@@ -139,7 +139,8 @@ export const createSoloBounty: CreateBountyFunction = async (
       description,
       options
     );
-    await transaction.wait();
+    const receipt = await transaction.wait();
+    return receipt;
   } catch (error) {
     console.error('Error creating bounty:', error);
     throw error;
@@ -165,7 +166,8 @@ export const createOpenBounty: CreateBountyFunction = async (
       description,
       options
     );
-    await transaction.wait();
+    const receipt = await transaction.wait();
+    return receipt;
   } catch (error) {
     console.error('Error creating bounty:', error);
     throw error;

--- a/src/components/global/Form.tsx
+++ b/src/components/global/Form.tsx
@@ -1,5 +1,6 @@
 import { useDynamicContext } from '@dynamic-labs/sdk-react-core';
 import { Switch } from '@mui/material';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 
@@ -9,6 +10,7 @@ import { createOpenBounty, createSoloBounty } from '@/app/context/web3';
 
 const Form = () => {
   const { primaryWallet } = useDynamicContext();
+  const router = useRouter();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [amount, setAmount] = useState('');
@@ -27,16 +29,19 @@ const Form = () => {
         toast.error('Insufficient funds for this transaction');
         return;
       }
+      let tx;
 
       if (isSoloBounty) {
-        await createSoloBounty(primaryWallet, name, description, amount);
+        tx = await createSoloBounty(primaryWallet, name, description, amount);
       } else {
-        await createOpenBounty(primaryWallet, name, description, amount);
+        tx = await createOpenBounty(primaryWallet, name, description, amount);
       }
       toast.success('Bounty created successfully!');
       setName('');
       setDescription('');
       setAmount('');
+      console.log('tx ', tx.logs[0].args[0]);
+      router.push(`/bounty/${tx.logs[0].args[0]}`);
     } catch (error: unknown) {
       console.error('Error creating bounty:', error);
       const errorCode = (error as any)?.info?.error?.code;

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -128,7 +128,7 @@ export type CreateBountyFunction = (
   name: string,
   description: string,
   value: string
-) => Promise<void>;
+) => Promise<any>;
 export type CreateClaimFunction = (
   primaryWallet: Wallet,
   name: string,


### PR DESCRIPTION
**Description**
- **Issue:** [#164](https://github.com/picsoritdidnthappen/poidh-app/issues/164)
- **Summary:**  When a user creates a bounty, the form will only reset but the user has to manually exit the form. and then navigate over to the specific bounty page.  With this revision, when a user submits a bounty, once the bounty is confirmed to be created, the page will automatically route over to the bounty page for the bounty.

**Changes Made**
-  changed the return type to any for the `CreateBountyFunction` on `web3.ts` in the types directory
- Transaction Receipt returns when transaction is confirmed for `createSoloBounty` and `createOpenBounty` on `web3.tsx`   in the app/context/ directory.
- imported `useRouter` from next/navigation to `form.tsx` in components/global directory.
- created router variable to allow navigation in `form.tsx` in components/global directory.
- created a variable `tx` to receive the transaction receipt in `form.tsx` in components/global directory.
- set `router.push('/bounty/${bountyId})` to navigate to bounty page in `form.tsx` in components/global directory.
 

**Verification**
- Manually tested the refresh page functionality with the degen chain by submitting various bounties.  

**PICS OR IT DIDNT HAPPEN**
Can not provide a video.  Can submit proof that it works if need be, but mr or ms or mrs reviewer, please try this out on your system first to make sure its not just only working on my system. 

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

**Additional Context**
- since I used it on my local device, I'm not sure about the speed it will run on prod.  If this is too slow, I can tweak it to try to optimize to speed. 
