### PR TITLE
fix: issue #392 

### DIFF
--- a/src/components/bounty/BountyMultiplayer.tsx
+++ b/src/components/bounty/BountyMultiplayer.tsx
@@ -89,12 +89,13 @@ export default function BountyMultiplayer({
         )}
       </div>
       {account.address?.toLocaleLowerCase() !== issuer.toLocaleLowerCase() &&
-        !isVoting &&
-        (inProgress && isCurrentUserAParticipant ? (
-          <Withdraw bountyId={bountyId} />
-        ) : (
-          <JoinBounty bountyId={bountyId} />
-        ))}
+      !isVoting &&
+      inProgress &&
+      isCurrentUserAParticipant ? (
+        <Withdraw bountyId={bountyId} />
+      ) : (
+        !isVoting && inProgress && <JoinBounty bountyId={bountyId} />
+      )}
     </>
   );
 }


### PR DESCRIPTION
Open bounties do not display 'Join bounty' button anymore.
Before:
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/d053b101-54f9-4f77-b645-6c2ede08ad2e">
After:
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/07ff7755-7613-45f3-8a5f-cd9acf7782e6">
