### PR TITLE
fix: always show transactions in reverse chrono order

### DIFF
--- a/src/components/bounty/BountyHistory.tsx
+++ b/src/components/bounty/BountyHistory.tsx
@@ -40,44 +40,46 @@ export default function BountyHistory({
 
       {showHistory && (
         <div className='divide-y divide-white/10'>
-          {transactions.map((transaction, index) => (
-            <div
-              key={`${transaction.tx}-${index}`}
-              className='flex items-center p-4 hover:bg-[#D1ECFF]/10 transition-all'
-            >
-              <div className='flex flex-col sm:flex-row sm:items-center w-full gap-2 sm:gap-4'>
-                <div className='flex items-center gap-1 min-w-[200px]'>
-                  {transaction.address !== '0x00' && (
-                    <>
-                      <CopyAddressButton
-                        address={transaction.address}
-                        size={12}
-                      />
-                      <DisplayAddress
-                        chain={chain}
-                        address={transaction.address}
-                      />
-                    </>
-                  )}
-                </div>
+          {transactions
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .map((transaction, index) => (
+              <div
+                key={`${transaction.tx}-${index}`}
+                className='flex items-center p-4 hover:bg-[#D1ECFF]/10 transition-all'
+              >
+                <div className='flex flex-col sm:flex-row sm:items-center w-full gap-2 sm:gap-4'>
+                  <div className='flex items-center gap-1 min-w-[200px]'>
+                    {transaction.address !== '0x00' && (
+                      <>
+                        <CopyAddressButton
+                          address={transaction.address}
+                          size={12}
+                        />
+                        <DisplayAddress
+                          chain={chain}
+                          address={transaction.address}
+                        />
+                      </>
+                    )}
+                  </div>
 
-                <Link
-                  className='flex items-center justify-between w-full sm:justify-start gap-4'
-                  href={chain.explorer + transaction.tx}
-                  target='_blank'
-                >
-                  <div className='px-2 py-0.5 rounded-md bg-white/10 text-sm'>
-                    {transaction.action}
-                  </div>
-                  <div className='text-sm text-white/60'>
-                    {new Date(
-                      transaction.timestamp * 1000
-                    ).toLocaleDateString()}
-                  </div>
-                </Link>
+                  <Link
+                    className='flex items-center justify-between w-full sm:justify-start gap-4'
+                    href={chain.explorer + transaction.tx}
+                    target='_blank'
+                  >
+                    <div className='px-2 py-0.5 rounded-md bg-white/10 text-sm'>
+                      {transaction.action}
+                    </div>
+                    <div className='text-sm text-white/60'>
+                      {new Date(
+                        transaction.timestamp * 1000
+                      ).toLocaleDateString()}
+                    </div>
+                  </Link>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
Even though I couldn't reproduce this, this fix should help - 

https://github.com/picsoritdidnthappen/poidh-app/issues/548

<img width="899" alt="Screenshot 2025-05-09 at 1 48 01 PM" src="https://github.com/user-attachments/assets/41102331-683f-4137-8ede-25716f7e3ba5" />

I put it in reverse because that makes the most sense to me...