### PR TITLE
feat: add native mobile share functionality and fix database schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,7 @@ model Bounties {
   transactions   Transactions[]
 
   @@id([id, chain_id])
-  @@schema("f5c72623-8a40-4503-b1a8-5b749dddeaf5")
+  @@schema("public")
 }
 
 model Claims {

--- a/src/components/bounty/BountyInfo.tsx
+++ b/src/components/bounty/BountyInfo.tsx
@@ -29,6 +29,7 @@ import { setLoadingAtom } from '@/store/loading';
 import TextWithLinks from '@/components/global/TextWithLinks';
 import FarcasterIcon from '@/components/global/FarcasterIcon';
 import XLink from '@/components/global/TwitterXLink';
+import ShareButton from '@/components/global/ShareButton';
 
 export default function BountyInfo({ bountyId }: { bountyId: string }) {
   const chain = useGetChain();
@@ -221,6 +222,12 @@ export default function BountyInfo({ bountyId }: { bountyId: string }) {
           </p>
         </div>
         <div className='flex flex-col space-between'>
+          <div className='flex items-center gap-2'>
+            <ShareButton
+              url={`https://poidh.xyz/${chain.slug}/bounty/${bountyId}`}
+              title={bounty.data.title}
+            />
+          </div>
           {bounty.data.inProgress ? (
             account.address?.toLocaleLowerCase() ===
               bounty.data.issuer.toLocaleLowerCase() &&

--- a/src/components/global/Icons.tsx
+++ b/src/components/global/Icons.tsx
@@ -602,3 +602,29 @@ export function LookupIcon({
     </svg>
   );
 }
+
+export function ShareIcon({
+  width = 24,
+  height = 24,
+}: {
+  width?: number;
+  height?: number;
+}) {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox='0 0 24 24'
+      strokeWidth={1.5}
+      stroke='currentColor'
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314a2.25 2.25 0 1 1 .434 2.44L7.217 13.134m0-2.186 9.566 5.314a2.25 2.25 0 1 1-.434 2.44L7.217 10.907Z'
+      />
+    </svg>
+  );
+}

--- a/src/components/global/ShareButton.tsx
+++ b/src/components/global/ShareButton.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { ShareIcon } from '@/components/global/Icons';
+import { useScreenSize } from '@/hooks/useScreenSize';
+import { useState, useEffect } from 'react';
+import { toast } from 'react-toastify';
+
+export default function ShareButton({
+  url,
+  title,
+  size = 20,
+}: {
+  url: string;
+  title?: string;
+  size?: number;
+}) {
+  const isMobile = useScreenSize();
+  const [isSharing, setIsSharing] = useState(false);
+  const [canShare, setCanShare] = useState(false);
+
+  useEffect(() => {
+    setCanShare(
+      typeof navigator !== 'undefined' && 'share' in navigator && isMobile
+    );
+  }, [isMobile]);
+
+  const handleShare = async () => {
+    if (isSharing) return;
+    setIsSharing(true);
+
+    try {
+      // Check if native sharing is available (mobile browsers)
+      if (canShare) {
+        await navigator.share({
+          title: title || 'Check out this bounty',
+          url: url,
+        });
+      } else {
+        // Fallback to clipboard
+        await navigator.clipboard.writeText(url);
+        toast.success('Link copied to clipboard');
+      }
+    } catch (error) {
+      // If user cancelled native share, don't fallback to clipboard
+      if (error instanceof Error && error.name === 'AbortError') {
+        // User cancelled the share - do nothing
+        return;
+      }
+
+      // For other errors, try clipboard as fallback
+      try {
+        await navigator.clipboard.writeText(url);
+        toast.success('Link copied to clipboard');
+      } catch (clipboardError) {
+        toast.error('Failed to share');
+      }
+    } finally {
+      setTimeout(() => setIsSharing(false), 1000);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleShare}
+      disabled={isSharing}
+      className='cursor-pointer hover:text-gray-200 shrink-0 p-2'
+      title={canShare ? 'Share' : 'Copy link'}
+    >
+      <ShareIcon width={size} height={size} />
+    </button>
+  );
+}


### PR DESCRIPTION
- Add ShareButton component with native mobile share API support
- Add ShareIcon to global icons collection
- Integrate share button into BountyInfo component
- Fix Prisma schema to use correct database schema (public vs custom)
- Implement proper mobile/desktop detection for share vs clipboard copy
- Handle user cancellation gracefully without fallback

🤖 Generated with [Claude Code](https://claude.ai/code)

sent Kenny a video of the demo