### PR TITLE
feat: add user voting status check in Voting component

### DIFF
--- a/src/components/bounty/Voting.tsx
+++ b/src/components/bounty/Voting.tsx
@@ -1,10 +1,10 @@
 import { PieChart } from 'react-minimal-pie-chart';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { toast } from 'react-toastify';
 import { formatEther } from 'viem';
 
 import { useGetChain } from '@/hooks/useGetChain';
-import { bountyVotingTracker } from '@/utils/web3';
+import { bountyVotingTracker, hasUserVotedOnBounty } from '@/utils/web3';
 import { useAccount, useSwitchChain, useWriteContract } from 'wagmi';
 import abi from '@/constant/abi/abi';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -37,13 +37,27 @@ export default function Voting({
   const setLoading = useSetAtom(setLoadingAtom);
   const setPollingChainId = useSetAtom(pollingChainIdAtom);
 
-  // State to track if user has already voted
-  const [hasUserVoted, setHasUserVoted] = useState(false);
-
   const voting = useQuery({
     queryKey: ['bountyVotingTracker', { id: bountyId, chainName: chain.slug }],
     queryFn: () => bountyVotingTracker({ id: bountyId, chainName: chain.slug }),
   });
+
+  // Query to check if user has already voted
+  const userVotingStatus = useQuery({
+    queryKey: [
+      'hasUserVoted',
+      { bountyId, chainName: chain.slug, userAddress: account.address },
+    ],
+    queryFn: () =>
+      hasUserVotedOnBounty({
+        chainName: chain.slug,
+        bountyId,
+        userAddress: account.address as string,
+      }),
+    enabled: !!account.address && !!bountyId,
+  });
+
+  const hasUserVoted = userVotingStatus.data ?? false;
 
   const bounty = trpc.bounty.useQuery({
     id: Number(bountyId),
@@ -61,11 +75,6 @@ export default function Voting({
   );
   const isVotingInProgress =
     parseInt(voting.data?.deadline ?? '0') * 1000 > Date.now();
-
-  // Reset voting state when account or bounty changes
-  useEffect(() => {
-    setHasUserVoted(false);
-  }, [account.address, bountyId]);
 
   const voteMutation = useMutation({
     mutationFn: async ({
@@ -95,15 +104,17 @@ export default function Voting({
     },
     onSuccess: () => {
       toast.success('Voted successfully');
-      setHasUserVoted(true); // Mark that user has voted
+      userVotingStatus.refetch(); // Refetch voting status
     },
     onError: (error) => {
       // Check if the error is due to already voting
-      if (error.message.includes('AlreadyVoted')) {
-        setHasUserVoted(true);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      if (errorMessage.includes('AlreadyVoted')) {
+        userVotingStatus.refetch(); // Refetch to update status
         toast.info('You have already voted on this claim');
       } else {
-        toast.error('Failed to vote: ' + error.message);
+        toast.error('Failed to vote: ' + errorMessage);
       }
     },
     onSettled: () => {
@@ -223,7 +234,8 @@ export default function Voting({
           <div className='flex flex-row gap-x-5 '>
             {isVotingInProgress
               ? isBountyContributor &&
-                !hasUserVoted && (
+                !hasUserVoted &&
+                !userVotingStatus.isLoading && (
                   <div>
                     <div className='mt-3'>what is your vote?</div>
                     <div className='flex flex-row gap-x-5 mt-2'>
@@ -280,6 +292,14 @@ export default function Voting({
                 You have already cast your vote for this claim.
               </div>
             )}
+            {/* Show loading state when checking voting status */}
+            {isVotingInProgress &&
+              isBountyContributor &&
+              userVotingStatus.isLoading && (
+                <div className='mt-3 text-gray-300'>
+                  Checking voting status...
+                </div>
+              )}
           </div>
 
           {!isAcceptedBounty && (

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -87,3 +87,44 @@ export function calcId({
 export function formatWalletAddress(address: string): string {
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
+
+export async function hasUserVotedOnBounty({
+  chainName,
+  bountyId,
+  userAddress,
+}: {
+  chainName: 'degen' | 'arbitrum' | 'base';
+  bountyId: string;
+  userAddress: string;
+}): Promise<boolean> {
+  try {
+    const chain = chains[chainName];
+
+    // Try to simulate the voting call to see if it would throw AlreadyVoted error
+    await chain.provider.simulateContract({
+      abi: ABI,
+      address: chain.contracts.mainContract as `0x${string}`,
+      functionName: 'voteClaim',
+      args: [BigInt(bountyId), true], // Vote value doesn't matter for simulation
+      account: userAddress as `0x${string}`,
+    });
+
+    // If no error is thrown, user hasn't voted yet
+    return false;
+  } catch (error: unknown) {
+    // If AlreadyVoted error is thrown, user has already voted
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const shortMessage = (error as { shortMessage?: string })?.shortMessage;
+
+    if (
+      errorMessage?.includes('AlreadyVoted') ||
+      shortMessage?.includes('AlreadyVoted')
+    ) {
+      return true;
+    }
+
+    // For other errors (like insufficient funds, not a contributor, etc.),
+    // we assume the user hasn't voted but can't vote for other reasons
+    return false;
+  }
+}


### PR DESCRIPTION
This PR resolves [#681](https://github.com/picsoritdidnthappen/poidh-app/issues/681) by ensuring the voting interface properly reflects the user's voting status, even after a page refresh. Previously, the voting state was tracked only on the frontend, causing the voting buttons to reappear after a refresh. This fix moves the voting status check to the blockchain, ensuring accurate and persistent behavior.

### Changes Made:
1. **Added a new utility function**:
   - Created `hasUserVotedOnBounty` in web3.ts to simulate a voting call and determine if the user has already voted by catching the `AlreadyVoted` error from the smart contract.

2. **Updated the `BountyClaims` component**:
   - Removed the frontend-only `hasUserVoted` state.
   - Added a React Query to fetch the user's voting status from the blockchain.
   - Updated the voting interface to conditionally render based on the blockchain data.
   - Added a loading state for better UX while checking voting status.

3. **Improved mutation handlers**:
   - Refetch the voting status after a successful vote or error to ensure the UI reflects the latest state.

- Closes #681