### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: 🤌 Setup pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
Updates actions/checkout to the latest stable version v4.

Changes:

Updates all instances to actions/checkout@v4
This is the last file requiring this update, all other files have been updated
Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2