### PR TITLE
CI upgrade

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: 🤌 Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 


### PR DESCRIPTION
uses: pnpm/action-setup@v2 -> uses: pnpm/action-setup@v4
Why: Keeps our workflow on the maintained major version, gains fixes and improvements, and avoids deprecation issues.

Proof: pnpm/action-setup v4 release - https://github.com/pnpm/action-setup/releases/tag/v4.1.0