### PR TITLE
Hide "create claim" button after a bounty is accepted; fix for issue #967

### DIFF
--- a/src/components/claims/CreateClaim.tsx
+++ b/src/components/claims/CreateClaim.tsx
@@ -18,7 +18,9 @@ export default function CreateClaim({ bountyId }: { bountyId: string }) {
     chainId: chain.id,
   });
 
-  if (!bounty.data?.inProgress) {
+  const hasAcceptedClaim = bounty.data?.claims?.some(claim => claim.is_accepted === true);
+  
+  if (!bounty.data?.inProgress || hasAcceptedClaim) {
     return null;
   }
 

--- a/src/components/claims/CreateClaim.tsx
+++ b/src/components/claims/CreateClaim.tsx
@@ -18,9 +18,7 @@ export default function CreateClaim({ bountyId }: { bountyId: string }) {
     chainId: chain.id,
   });
 
-  const hasAcceptedClaim = bounty.data?.claims?.some(claim => claim.is_accepted === true);
-  
-  if (!bounty.data?.inProgress || hasAcceptedClaim) {
+  if (!bounty.data?.inProgress) {
     return null;
   }
 

--- a/src/components/global/NavBarMobile.tsx
+++ b/src/components/global/NavBarMobile.tsx
@@ -4,6 +4,8 @@ import { useAccount } from 'wagmi';
 import FormBounty from '../bounty/FormBounty';
 import FormClaim from '../claims/FormClaim';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
+import { useGetChain } from '@/hooks/useGetChain';
+import { trpc } from '@/trpc/client';
 
 export default function NavBarMobile({
   type,
@@ -19,7 +21,21 @@ export default function NavBarMobile({
   const [showForm, setShowForm] = useState(false);
   const account = useAccount();
   const { openConnectModal } = useConnectModal();
+  const chain = useGetChain();
 
+  const bounty = trpc.bounty.useQuery(
+    {
+      id: Number(bountyId),
+      chainId: chain.id,
+    },
+    {
+      enabled: type === 'claim' && !!bountyId,
+    }
+  );
+  if (type === 'claim' && !bounty.data?.inProgress) {
+    return null;
+  }
+  
   return (
     <>
       <nav


### PR DESCRIPTION
I updated the createclaim file. The original file only checked whether the bounty is in progress but I updated it to also check if the bounty is completed. I hope it works since I wasn't able test with Chrome.