### PR TITLE
fix: show thank you message for bounty owner who has voted

### DIFF
--- a/src/components/bounty/Voting.tsx
+++ b/src/components/bounty/Voting.tsx
@@ -278,6 +278,15 @@ export default function Voting({
                 </div>
               )}
 
+            {/* Show thank you message for bounty owner who has already voted (their vote is automatic) */}
+            {isVotingInProgress && isBountyOwner && !isBountyContributor && (
+              <div className='p-4 rounded-lg border text-center'>
+                <p className='text-sm font-medium'>
+                  ✓ Thank you for your vote!
+                </p>
+              </div>
+            )}
+
             {isVotingInProgress && isBountyContributor && userHasVoted.data && (
               <div className='p-4 rounded-lg border text-center'>
                 <p className='text-sm font-medium'>


### PR DESCRIPTION
Fixes issue #1219

- Add condition to display 'Thank you for your vote!' message for bounty owner
- Bounty owners have automatic voting, so they shouldn't see voting buttons
- The bounty creator's vote is automatic when they submit a claim, so they should see the thank you message instead of the voting interface