### PR TITLE
fix: responsive input padding for small screens

### DIFF
--- a/src/components/bounty/FormJoinBounty.tsx
+++ b/src/components/bounty/FormJoinBounty.tsx
@@ -139,10 +139,10 @@ export default function FormJoinBounty({
                   value={amount}
                   onChange={handleAmountChange}
                   placeholder={`amount in ${chain.currency}`}
-                  className='border bg-transparent border-[#D1ECFF] py-2 px-2 rounded-md w-full pr-28 placeholder:text-slate-400 whitespace-nowrap'
+                  className='border bg-transparent border-[#D1ECFF] py-2 px-2 rounded-md w-full pr-16 sm:pr-28 placeholder:text-slate-400 whitespace-nowrap'
                 />
                 {usdPerToken !== null && (
-                  <span className='absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 font-semibold pointer-events-none max-w-[120px] truncate text-right'>
+                  <span className='absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 text-gray-300 font-semibold pointer-events-none max-w-[100px] sm:max-w-[120px] truncate text-right text-xs sm:text-sm'>
                     (${formatAmountShort({ amount: usdPerToken })})
                   </span>
                 )}


### PR DESCRIPTION
Fixes issue #1092

- Reduce right padding on small screens to prevent 'degen' text cutoff in Rainbow browser
- Make USD amount display responsive with smaller font on mobile
- Added sm: responsive classes for larger screens