### PR TITLE
Fix bounty creation log decoding and value-sort pagination

### DIFF
--- a/src/components/bounty/FormBounty.tsx
+++ b/src/components/bounty/FormBounty.tsx
@@ -124,20 +124,28 @@ export default function FormBounty({
         hash: tx,
       });
 
-      const log = receipt.logs[0];
-      if (!log) {
-        throw new Error('No logs found');
+      const bountyCreatedLog = receipt.logs.find((log) => {
+        try {
+          const data = decodeEventLog({
+            abi,
+            data: log.data,
+            topics: log.topics,
+          });
+          return data.eventName === 'BountyCreated';
+        } catch {
+          return false;
+        }
+      });
+
+      if (!bountyCreatedLog) {
+        throw new Error('BountyCreated event not found');
       }
 
       const data = decodeEventLog({
         abi,
-        data: log.data,
-        topics: log.topics,
+        data: bountyCreatedLog.data,
+        topics: bountyCreatedLog.topics,
       });
-
-      if (data.eventName !== 'BountyCreated') {
-        throw new Error('Invalid event: ' + data.eventName);
-      }
 
       for (let i = 0; i < 60; i++) {
         setLoading({ isLoading: true, status: `Indexing ${i}s...` });

--- a/src/components/bounty/FormBounty.tsx
+++ b/src/components/bounty/FormBounty.tsx
@@ -62,7 +62,7 @@ export default function FormBounty({
     {
       enabled: !!album,
       staleTime: 30_000,
-    }
+    },
   );
 
   useEffect(() => {
@@ -173,8 +173,10 @@ export default function FormBounty({
         album,
       });
       setLoading({ isLoading: true, status: 'Redirecting...' });
+      const indexedChain = chains.find((chain) => chain.id === chainId);
+      const targetSlug = indexedChain?.slug ?? currentChain.slug;
       router.push(
-        `/${currentChain.slug}/bounty/${bountyId}?indexing=true&showSuccessCreationModal=true`
+        `/${targetSlug}/bounty/${bountyId}?indexing=true&showSuccessCreationModal=true`,
       );
       toast.success('Bounty created successfully');
     },
@@ -494,7 +496,7 @@ export default function FormBounty({
             <button
               className={cn(
                 'flex flex-row items-center justify-center',
-                account.isDisconnected && 'opacity-50 cursor-not-allowed'
+                account.isDisconnected && 'opacity-50 cursor-not-allowed',
               )}
               onClick={() => {
                 if (name && description && amount) {
@@ -505,7 +507,7 @@ export default function FormBounty({
 
                   if (Number(amount) < minValue) {
                     toast.error(
-                      `Minimum amount is ${minValue} ${currentChain.currency.toUpperCase()}`
+                      `Minimum amount is ${minValue} ${currentChain.currency.toUpperCase()}`,
                     );
                     return;
                   }
@@ -526,7 +528,7 @@ export default function FormBounty({
                   createBountyMutations.mutate(formData);
                 } else {
                   toast.error(
-                    'Please fill in all required fields and check wallet connection.'
+                    'Please fill in all required fields and check wallet connection.',
                   );
                 }
               }}

--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -114,7 +114,13 @@ export const bountiesRouter = {
               ban: {
                 none: {},
               },
-              inProgress: true,
+              ...(input.status === 'past'
+                ? {
+                    inProgress: false,
+                  }
+                : {
+                    inProgress: true,
+                  }),
               isCanceled: false,
               ...(input.status === 'open'
                 ? {
@@ -123,10 +129,6 @@ export const bountiesRouter = {
                 : input.status === 'progress'
                 ? {
                     isVoting: true,
-                  }
-                : input.status === 'past'
-                ? {
-                    inProgress: false,
                   }
                 : {}),
             },
@@ -188,7 +190,13 @@ export const bountiesRouter = {
           },
 
           where: {
-            inProgress: true,
+            ...(input.status === 'past'
+              ? {
+                  inProgress: false,
+                }
+              : {
+                  inProgress: true,
+                }),
             isCanceled: false,
             ban: {
               none: {},
@@ -209,10 +217,6 @@ export const bountiesRouter = {
               : input.status === 'progress'
               ? {
                   isVoting: true,
-                }
-              : input.status === 'past'
-              ? {
-                  inProgress: false,
                 }
               : {}),
           },

--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -134,7 +134,7 @@ export const bountiesRouter = {
             },
 
             ...(input.cursor
-              ? { amountSort: { lt: input.cursor.amountSort } }
+              ? { amountSort: { lte: input.cursor.amountSort } }
               : {}),
           },
           select: {
@@ -158,7 +158,7 @@ export const bountiesRouter = {
             amountSort: true,
           },
           orderBy: { amountSort: 'desc' },
-          take: input.limit,
+          take: input.limit + 1,
         });
 
         items = bountiesExtra.map((e) => ({
@@ -222,7 +222,7 @@ export const bountiesRouter = {
           },
 
           orderBy: { createdAt: 'desc' },
-          take: input.limit,
+          take: input.limit + 1,
         });
 
         items = bounties.map(({ extra, ...bounty }) => ({
@@ -239,7 +239,11 @@ export const bountiesRouter = {
           }
         | undefined = undefined;
 
-      if (items.length === input.limit) {
+      const hasMore = items.length > input.limit;
+
+      if (hasMore) {
+        items = items.slice(0, input.limit);
+
         const last = items[items.length - 1];
 
         nextCursor = {
@@ -323,11 +327,15 @@ export const bountiesRouter = {
         },
 
         orderBy: { createdAt: 'desc' },
-        take: input.limit,
+        take: input.limit + 1,
       });
 
       let nextCursor: number | undefined = undefined;
-      if (items.length === input.limit) {
+      const hasMore = items.length > input.limit;
+
+      if (hasMore) {
+        items = items.slice(0, input.limit);
+
         nextCursor = items[items.length - 1].id;
       }
 
@@ -528,11 +536,15 @@ export const bountiesRouter = {
 
         distinct: 'id',
         orderBy: { createdAt: 'desc' },
-        take: input.limit,
+        take: input.limit + 1,
       });
 
       let nextCursor: string | undefined = undefined;
-      if (items.length === input.limit) {
+      const hasMore = items.length > input.limit;
+
+      if (hasMore) {
+        items = items.slice(0, input.limit);
+
         nextCursor = items[items.length - 1].createdAt.toString();
       }
 

--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -134,7 +134,7 @@ export const bountiesRouter = {
             },
 
             ...(input.cursor
-              ? { amountSort: { lte: input.cursor.amountSort } }
+              ? { amountSort: { lt: input.cursor.amountSort } }
               : {}),
           },
           select: {


### PR DESCRIPTION
This PR fixes two bounty-related issues.

## 1) Correct bounty ID extraction after create (Issue #1185)
- Do not assume  is the bounty event.
- Scan and decode logs to find the actual  event.
- Use the decoded bounty ID for album assignment and redirect.

## 2) Homepage value-sort pagination dropping bounties (Issue #1216)
- Fix cursor boundary behavior in value sorting pagination.
- Prevent records with equal  values from being skipped between pages.

This keeps pagination complete and stable while preserving order.

Fixes #1185
Fixes #1216

/claim #1185
/claim #1216