### PR TITLE
Fix #1219: guard hasVoted query until wallet is connected

### DIFF
--- a/src/components/bounty/Voting.tsx
+++ b/src/components/bounty/Voting.tsx
@@ -54,11 +54,16 @@ export default function Voting({
     account?.address?.toLocaleLowerCase() ===
     bounty.data?.issuer?.toLocaleLowerCase();
 
-  const userHasVoted = trpc.accounts.hasVoted.useQuery({
-    address: account.address?.toLowerCase() ?? '',
-    bountyId: Number(bountyId),
-    chainId: chain.id,
-  });
+  const userHasVoted = trpc.accounts.hasVoted.useQuery(
+    {
+      address: account.address?.toLowerCase() ?? '',
+      bountyId: Number(bountyId),
+      chainId: chain.id,
+    },
+    {
+      enabled: !!account.address,
+    }
+  );
 
   const bountyContibutors = trpc.bounties.participations.useQuery({
     chainId: chain.id,


### PR DESCRIPTION
This PR addresses #1219 by preventing `hasVoted` from querying with an empty address before wallet connection state is available.

### What changed
- Updated `src/components/bounty/Voting.tsx` to add `enabled: !!account.address` to `trpc.accounts.hasVoted.useQuery`.
- Prevents vote UI from being derived from a premature/invalid request keyed by empty address.

### Why
Issue #1219 reports incorrect display behavior for the "Thank you for your vote" message. This component gates vote buttons vs. confirmation text based on `userHasVoted.data`. Querying before wallet address exists can produce misleading state/caching behavior.

### Validation
- Attempted to run tests/lint locally, but dependency install fails in this environment due to upstream peer dependency conflicts (`npm install` ERESOLVE).

Fixes #1219
/claim #1219