### PR TITLE
Fix close (X) button not clickable in claim success modal

### DIFF
--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -114,7 +114,6 @@ export const bountiesRouter = {
               ban: {
                 none: {},
               },
-              inProgress: true,
               isCanceled: false,
               ...(input.status === 'open'
                 ? {
@@ -188,7 +187,6 @@ export const bountiesRouter = {
           },
 
           where: {
-            inProgress: true,
             isCanceled: false,
             ban: {
               none: {},


### PR DESCRIPTION
## Summary
- adds  to the close button in 
- keeps close control clickable when overlapping layers occur (reported on Rainbow browser)

## Testing
- attempted test run but local env lacks jest binary ()
- change is isolated to one className adjustment

Fixes #1215
/claim #1215