### PR TITLE
Fix homepage value sort hiding eligible bounties

### DIFF
--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -114,7 +114,6 @@ export const bountiesRouter = {
               ban: {
                 none: {},
               },
-              inProgress: true,
               isCanceled: false,
               ...(input.status === 'open'
                 ? {
@@ -188,7 +187,6 @@ export const bountiesRouter = {
           },
 
           where: {
-            inProgress: true,
             isCanceled: false,
             ban: {
               none: {},


### PR DESCRIPTION
This PR fixes homepage sorting behavior where some bounties were missing under default **by value** sort (but visible under **by date**), as reported in #1216.

### Root cause
`bounties.fetchAll` always enforced `inProgress: true` in the query `where` clause. That condition conflicted with the `status === 'past'` branch (`inProgress: false`), making past bounties impossible to return in that path and causing inconsistent sorting visibility.

### What changed
- Removed unconditional `inProgress: true` from both code paths in `fetchAll`:
  - `prisma.bountiesExtra.findMany` (value sort path)
  - `prisma.bounties.findMany` (date sort path)
- Kept status-specific filtering logic intact (`open/progress/past` branches still set the correct `inProgress`/`isVoting` constraints).

### Result
- Value sort and date sort now use consistent status filtering behavior.
- Eligible bounties no longer disappear due to contradictory query constraints.

Fixes #1216
/claim #1216
