### PR TITLE
fix: position toast messages at top-right

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -103,7 +103,7 @@ export default function RootLayout({
           <WalletProvider>
             <LoadingLayout>
               <ClientLayout>{children}</ClientLayout>
-              <ToastContainer />
+              <ToastContainer position="top-right" />
               <CryptoWalletMobilePopup />
             </LoadingLayout>
           </WalletProvider>


### PR DESCRIPTION
## Summary
Fixes issue #1180 - Toast messages showing up down the page instead of at the top.

## Changes
- Added `position="top-right"` to ToastContainer in layout.tsx to ensure toast messages appear at the top-right of the page instead of slightly down from the header.