### PR TITLE
feat: add motion feedback to button clicks

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -130,6 +130,46 @@ body {
 
 button {
   text-transform: lowercase;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button:hover {
+  transform: scale(1.02);
+}
+
+button:active {
+  transform: scale(0.96) !important;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* Motion feedback for clickable cards */
+[role='button'],
+.clickable-card,
+.button {
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+[role='button']:hover,
+.clickable-card:hover {
+  transform: scale(1.02);
+}
+
+[role='button']:active,
+.clickable-card:active {
+  transform: scale(0.98);
+}
+
+/* Bounty item hover effects */
+.bountyItem a > div {
+  transition: transform 0.15s ease;
+}
+
+.bountyItem a:hover > div {
+  transform: translateY(-2px);
+}
+
+.bountyItem a:active > div {
+  transform: translateY(0) scale(0.99);
 }
 
 .otherClaims .submitForVote {


### PR DESCRIPTION
## Summary

Adds visual motion feedback to buttons and clickable elements when clicked, similar to poidh classic.

## Changes

- **Buttons**: Added subtle scale up on hover (1.02x) and scale down on click (0.96x)
- **Bounty cards**: Added hover lift effect (translateY -2px) and click press effect
- **Clickable cards**: Added scale transforms for interactive feedback

## Motivation

Requested in issue #1178 - users noticed the nice button feedback in poidh classic and wanted the same in the new version.

## Testing

- Lint passes with no new warnings
- CSS changes are additive and non-breaking

Closes #1178