### PR TITLE
fix: calculate USD value dynamically for past bounties

### DIFF
--- a/src/components/bounty/PastBountyCard.tsx
+++ b/src/components/bounty/PastBountyCard.tsx
@@ -21,6 +21,11 @@ export default function PastBountyCard({ bounty }: { bounty: Bounty }) {
   }
 
   const chain = getChainById({ chainId: claim.data.chainId as ChainId });
+  
+  // Fetch current price to calculate accurate USD value
+  const price = trpc.web3.fetchPrice.useQuery({ currency: chain.currency });
+  const tokenAmount = formatEther(BigInt(bounty.amount));
+  const currentUsdAmount = price.data ? parseFloat(tokenAmount) * price.data : bounty.amountSort;
 
   return (
     <>
@@ -73,8 +78,8 @@ export default function PastBountyCard({ bounty }: { bounty: Bounty }) {
             <div className='flex items-center'>
               <span className='text-md mr-3'>
                 {formatSortAmount({
-                  usdAmount: bounty.amountSort,
-                  amount: formatEther(BigInt(bounty.amount)),
+                  usdAmount: currentUsdAmount,
+                  amount: tokenAmount,
                   currency: chain.currency,
                 })}
               </span>


### PR DESCRIPTION
## Summary

Fixes issue #1179 - "Improper price calculation on past bounties"

## Problem

The past bounties page was showing incorrect USD values because it was using the stored `amountSort` value from the database, which represents the USD value at the time the bounty was created. When the token price changes significantly, the displayed value becomes inaccurate.

For example, a bounty that was worth $1000 when created might only be worth $0.30 at current prices due to token price changes.

## Solution

Instead of using the stored `amountSort` value, we now:
1. Fetch the current token price from the price API
2. Calculate the USD value dynamically: `token_amount * current_price`
3. Fall back to the stored `amountSort` if the price fetch fails (for backward compatibility)

This ensures that past bounties always display accurate USD values based on current market prices.

## Changes

- Modified `PastBountyCard.tsx` to fetch current price and calculate USD value dynamically
- Added trpc.web3.fetchPrice query to get the current token price
- Calculate `currentUsdAmount = tokenAmount * price` instead of using stored `amountSort`