### PR TITLE
fix: prevent degen placeholder text overflow on small screens

### DIFF
--- a/src/components/bounty/FormJoinBounty.tsx
+++ b/src/components/bounty/FormJoinBounty.tsx
@@ -139,7 +139,7 @@ export default function FormJoinBounty({
                   value={amount}
                   onChange={handleAmountChange}
                   placeholder={`amount in ${chain.currency}`}
-                  className='border bg-transparent border-[#D1ECFF] py-2 px-2 rounded-md w-full pr-28 placeholder:text-slate-400 whitespace-nowrap'
+                  className='border bg-transparent border-[#D1ECFF] py-2 px-2 rounded-md w-full md:pr-28 pr-16 placeholder:text-slate-400'
                 />
                 {usdPerToken !== null && (
                   <span className='absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 font-semibold pointer-events-none max-w-[120px] truncate text-right'>


### PR DESCRIPTION
## Description

Fixes issue #1092 - 'degen' text not showing up in Rainbow browser

## Changes

- Removed `whitespace-nowrap` from input placeholder to allow text wrapping
- Changed right padding from fixed `pr-28` to responsive `md:pr-28 pr-16`
- On mobile/small screens (like Rainbow browser), padding is reduced from 7rem to 4rem to give more room for the placeholder text

## Before/After

Before: The placeholder text "amount in degen" would overflow and be cut off on small screens
After: The text wraps properly and remains visible on all screen sizes

## Testing

Verified TypeScript syntax is valid