### PR TITLE
feat: display current wallet balance on funding screens

### DIFF
--- a/src/components/bounty/FormBounty.tsx
+++ b/src/components/bounty/FormBounty.tsx
@@ -10,7 +10,7 @@ import {
 import { useEffect, useState, useRef } from 'react';
 import { toast } from 'react-toastify';
 import { useChainInfo } from '@/hooks/useChainInfo';
-import { useAccount, useSwitchChain, useWriteContract } from 'wagmi';
+import { useAccount, useSwitchChain, useWriteContract, useBalance } from 'wagmi';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter, usePathname } from 'next/navigation';
 import { decodeEventLog, parseEther } from 'viem';
@@ -87,6 +87,11 @@ export default function FormBounty({
   const setLoading = useSetAtom(setLoadingAtom);
   const setPollingChainId = useSetAtom(pollingChainIdAtom);
   const saveBountyAlbum = trpc.bounties.addToAlbum.useMutation();
+
+  const { data: balance } = useBalance({
+    address: account.address,
+    chainId: chain?.id,
+  });
 
   const createBountyMutations = useMutation({
     mutationFn: async (formData: {
@@ -312,6 +317,14 @@ export default function FormBounty({
             }}
           ></textarea>
 
+          {balance && (
+            <div className='text-xs text-gray-400 mb-2'>
+              Balance:{' '}
+              <span className='font-semibold text-gray-200'>
+                {balance.formatted} {currentChain.currency}
+              </span>
+            </div>
+          )}
           <span className={isMobile ? 'text-base mb-2' : ''}>reward</span>
           <div className='relative w-full mb-3'>
             <input

--- a/src/components/bounty/FormJoinBounty.tsx
+++ b/src/components/bounty/FormJoinBounty.tsx
@@ -4,7 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { parseEther } from 'viem';
-import { useAccount, useSwitchChain, useWriteContract } from 'wagmi';
+import { useAccount, useSwitchChain, useWriteContract, useBalance } from 'wagmi';
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { trpc, trpcClient } from '@/trpc/client';
 import { useAtomValue, useSetAtom } from 'jotai';
@@ -37,6 +37,11 @@ export default function FormJoinBounty({
   const setLoading = useSetAtom(setLoadingAtom);
   const setPollingChainId = useSetAtom(pollingChainIdAtom);
   const pollingChainId = useAtomValue(pollingChainIdAtom);
+
+  const { data: balance } = useBalance({
+    address: account.address,
+    chainId: chain.id,
+  });
 
   const price =
     trpc.web3.fetchPrice.useQuery({ currency: chain.currency }).data ?? 0;
@@ -129,6 +134,14 @@ export default function FormJoinBounty({
               <CloseIcon size={12} />
             </button>
             <div className='flex flex-col items-start w-full'>
+              {balance && (
+                <div className='text-xs text-gray-300 mb-3'>
+                  Balance:{' '}
+                  <span className='font-semibold text-white'>
+                    {balance.formatted} {chain.currency}
+                  </span>
+                </div>
+              )}
               <DialogTitle className='text-base mb-2 font-family-geist'>
                 Reward
               </DialogTitle>


### PR DESCRIPTION
## Summary

Display the user's current wallet balance on funding screens (bounty creation and add funds forms) to help users avoid insufficient balance errors.

## Changes

- Added `useBalance` hook from wagmi to FormJoinBounty.tsx and FormBounty.tsx
- Display balance above the reward input field in both forms
- Shows balance in the native currency (e.g., ETH, DEGEN)

## Why

Currently, users don't see their wallet balance when adding funds to bounties. This can lead to failed transactions when users accidentally try to add more than they have in their wallet, forcing them to restart the whole process.

Fixes #1125