### PR TITLE
fix: persist bounty form data across wallet rejections (#1277)

### DIFF
--- a/src/components/bounty/FormBounty.tsx
+++ b/src/components/bounty/FormBounty.tsx
@@ -48,6 +48,57 @@ export default function FormBounty({
   const [amount, setAmount] = useState('');
   const [album, setAlbum] = useState(prefilledAlbum);
   const [usdPerToken, setUsdPerToken] = useState<number | null>(null);
+
+  // Session storage key for persisting form data across rejected transactions
+  const FORM_DATA_KEY = 'poidh_bounty_form_draft';
+
+  // Load saved form draft when dialog opens
+  useEffect(() => {
+    if (open) {
+      try {
+        const saved = sessionStorage.getItem(FORM_DATA_KEY);
+        if (saved) {
+          const { savedName, savedDescription, savedAmount, savedAlbum, savedChain } = JSON.parse(saved);
+          if (savedName) setName(savedName);
+          if (savedDescription) setDescription(savedDescription);
+          if (savedAmount) setAmount(savedAmount);
+          if (savedAlbum !== undefined) setAlbum(savedAlbum);
+          if (savedChain && savedChain !== currentChain.slug) {
+            const ch = chains[savedChain as Netname];
+            if (ch) setCurrentChain(ch);
+          }
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+  }, [open]);
+
+  // Persist form data to sessionStorage whenever it changes
+  useEffect(() => {
+    if (open && (name || description || amount)) {
+      try {
+        sessionStorage.setItem(FORM_DATA_KEY, JSON.stringify({
+          savedName: name,
+          savedDescription: description,
+          savedAmount: amount,
+          savedAlbum: album,
+          savedChain: currentChain.slug,
+        }));
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  }, [name, description, amount, album, currentChain.slug, open]);
+
+  // Clear saved form data after successful bounty creation
+  const clearFormDraft = () => {
+    try {
+      sessionStorage.removeItem(FORM_DATA_KEY);
+    } catch {
+      // Ignore storage errors
+    }
+  };
   const [isOpenBounty, setIsOpenBounty] = useState(true);
   const [showAlbumDropdown, setShowAlbumDropdown] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -179,6 +230,7 @@ export default function FormBounty({
       setDescription('');
       setAmount('');
       setAlbum(prefilledAlbum);
+      clearFormDraft();
       setLoading({ isLoading: true, status: 'Redirecting...' });
       router.push(
         `/${currentChain.slug}/bounty/${bountyId}?indexing=true&showSuccessCreationModal=true`
@@ -187,6 +239,23 @@ export default function FormBounty({
     },
     onError: (error) => {
       toast.error('Failed to create bounty: ' + error.message);
+      // Restore form data from sessionStorage on rejection
+      try {
+        const saved = sessionStorage.getItem(FORM_DATA_KEY);
+        if (saved) {
+          const { savedName, savedDescription, savedAmount, savedAlbum, savedChain } = JSON.parse(saved);
+          if (savedName) setName(savedName);
+          if (savedDescription) setDescription(savedDescription);
+          if (savedAmount) setAmount(savedAmount);
+          if (savedAlbum !== undefined) setAlbum(savedAlbum);
+          if (savedChain && savedChain !== currentChain.slug) {
+            const ch = chains[savedChain as Netname];
+            if (ch) setCurrentChain(ch);
+          }
+        }
+      } catch {
+        // Ignore parse errors
+      }
     },
     onSettled: () => {
       setLoading({ isLoading: false, status: '' });


### PR DESCRIPTION
## Description

Fixes issue #1277: Save form information up until wallet confirmation.

When a user fills out the bounty creation form and then clicks "create bounty", their form data is now persisted to `sessionStorage` before the wallet transaction is initiated. If the user rejects the transaction or needs to change something, their form data is automatically restored when they return to the form.

## Changes

- Added `FORM_DATA_KEY` constant for sessionStorage key
- Added `useEffect` to load saved form draft when the dialog opens
- Added `useEffect` to persist form data to sessionStorage whenever it changes (name, description, amount, album, chain)
- Added `clearFormDraft()` helper to remove saved draft after successful bounty creation
- Modified `onSuccess` callback to clear saved draft after successful creation
- Modified `onError` callback to restore form data from sessionStorage on transaction rejection

## Testing

1. Fill out the bounty creation form (title, description, reward, album)
2. Click "create bounty" and confirm in wallet
3. Reject the wallet transaction
4. Verify form data is NOT cleared - all fields should retain their values
5. Alternatively close and reopen the dialog - form data should persist
6. On successful bounty creation, form data should be cleared from sessionStorage

Closes #1277