### PR TITLE
fix: refetch bounty data after veto resolution (#1295)

### DIFF
--- a/src/components/bounty/Voting.tsx
+++ b/src/components/bounty/Voting.tsx
@@ -137,6 +137,7 @@ export default function Voting({
     },
     onSettled: () => {
       voting.refetch();
+      bounty.refetch();
     },
   });
 


### PR DESCRIPTION
## Summary

After a veto vote is resolved, the bounty should reset to its pre-vote state (isVoting = false), allowing contributors to withdraw and the bounty creator to nominate a new winner. However, the UI was only refetching the voting data but not the bounty data after \esolveVote\ was called, causing the bounty to appear stuck in voting state.

## Root Cause

In \Voting.tsx\, the \esolveVoteMutation\ \onSettled\ callback only called \oting.refetch()\ but not \ounty.refetch()\. This meant the \ounty.data?.isVoting\ flag remained \	rue\ in the UI cache even after the on-chain state had been updated.

## Fix

Added \ounty.refetch()\ to the \onSettled\ callback of \esolveVoteMutation\ so that the bounty data (including the \isVoting\ flag) is refreshed after resolution.

`	sx
onSettled: () => {
  voting.refetch();
  bounty.refetch();  // <-- added
},
`

## Impact

- Contributors can now withdraw after a veto is resolved
- Bounty creator can nominate a new winner after a veto
- UI correctly reflects the post-resolution bounty state

## Issue

Fixes #1295