### PR TITLE
fix: keep claim bans stable when indexer remaps internal ids

### DIFF
--- a/migrations/013_ban_claim_on_chain_id.sql
+++ b/migrations/013_ban_claim_on_chain_id.sql
@@ -1,0 +1,14 @@
+-- Stable claim bans: internal claim id can change when indexer offsets change; on_chain_id is stable per chain.
+ALTER TABLE :schema."Ban" ADD COLUMN IF NOT EXISTS claim_on_chain_id INTEGER NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ban_chain_claim_on_chain
+  ON :schema."Ban"(chain_id, claim_on_chain_id)
+  WHERE claim_on_chain_id IS NOT NULL;
+
+UPDATE :schema."Ban" b
+SET claim_on_chain_id = c.on_chain_id
+FROM :schema."Claims" c
+WHERE b.claim_id IS NOT NULL
+  AND b.chain_id = c.chain_id
+  AND b.claim_id = c.id
+  AND b.claim_on_chain_id IS NULL;

--- a/migrations/014_reconcile_ban_claim_keys.sql
+++ b/migrations/014_reconcile_ban_claim_keys.sql
@@ -1,0 +1,27 @@
+-- Keep claim bans aligned with indexer-stable on-chain ids and current internal claim ids.
+
+-- 1) Backfill claim_on_chain_id from the current Claims row when still NULL.
+UPDATE :schema."Ban" b
+SET claim_on_chain_id = c.on_chain_id
+FROM :schema."Claims" c
+WHERE b.claim_id IS NOT NULL
+  AND b.chain_id = c.chain_id
+  AND b.claim_id = c.id
+  AND b.claim_on_chain_id IS NULL;
+
+-- 2) Point ban.claim_id at a current Claims.id for the same (chain, on-chain claim id).
+--    Internal ids can change when indexer offsets change; on_chain_id is stable.
+UPDATE :schema."Ban" b
+SET claim_id = c.id
+FROM (
+  SELECT DISTINCT ON (chain_id, on_chain_id)
+    chain_id,
+    on_chain_id,
+    id
+  FROM :schema."Claims"
+  ORDER BY chain_id, on_chain_id, id DESC
+) c
+WHERE b.claim_on_chain_id IS NOT NULL
+  AND b.chain_id = c.chain_id
+  AND c.on_chain_id = b.claim_on_chain_id
+  AND (b.claim_id IS DISTINCT FROM c.id);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,15 +113,19 @@ model UsersExtra {
 }
 
 model Ban {
-  id       Int      @id @default(autoincrement())
-  chainId  Int      @map("chain_id")
-  bountyId Int?     @map("bounty_id")
-  claimId  Int?     @map("claim_id")
-  bannedAt DateTime @default(now()) @map("banned_at")
-  bannedBy String   @map("banned_by")
+  id              Int      @id @default(autoincrement())
+  chainId         Int      @map("chain_id")
+  bountyId        Int?     @map("bounty_id")
+  claimId         Int?     @map("claim_id")
+  /// On-chain claim id for this chain; stable when indexer internal id shifts.
+  claimOnChainId  Int?     @map("claim_on_chain_id")
+  bannedAt        DateTime @default(now()) @map("banned_at")
+  bannedBy        String   @map("banned_by")
 
   bounty Bounties? @relation(fields: [bountyId, chainId], references: [id, chainId])
   claim  Claims?   @relation(fields: [claimId, chainId], references: [id, chainId])
+
+  @@index([chainId, claimOnChainId])
 }
 
 model Transactions {

--- a/src/trpc/claimBanFilter.ts
+++ b/src/trpc/claimBanFilter.ts
@@ -1,0 +1,92 @@
+import type { Prisma } from 'generated/prisma/client';
+import prisma from 'prisma/prisma';
+
+type BanRow = {
+  chainId: number;
+  claimId: number | null;
+  claimOnChainId: number | null;
+};
+
+let cached: { filter: Prisma.ClaimsWhereInput; expires: number } | null = null;
+/** Short TTL so new bans apply quickly across serverless instances. */
+const CACHE_TTL_MS = 5_000;
+
+export function invalidateClaimBanFilterCache() {
+  cached = null;
+}
+
+export function buildClaimsNotBannedWhereFromBanRows(
+  rows: BanRow[]
+): Prisma.ClaimsWhereInput {
+  const orExclude: Prisma.ClaimsWhereInput[] = [];
+  for (const b of rows) {
+    if (b.claimId != null) {
+      orExclude.push({ AND: [{ chainId: b.chainId }, { id: b.claimId }] });
+    }
+    if (b.claimOnChainId != null) {
+      orExclude.push({
+        AND: [{ chainId: b.chainId }, { onChainId: b.claimOnChainId }],
+      });
+    }
+  }
+  if (orExclude.length === 0) {
+    return { ban: { none: {} } };
+  }
+  // AND-of-NOT avoids some Prisma/SQL edge cases with NOT+OR on large lists and
+  // matches NOT (c1 OR c2 OR …) for independent row predicates.
+  return { AND: orExclude.map((condition) => ({ NOT: condition })) };
+}
+
+/**
+ * Rows in Ban that refer to a claim (by internal id and/or stable on-chain id).
+ * Resolves missing `claimOnChainId` from current `Claims` so filters stay correct
+ * after indexer remaps internal `id` while `on_chain_id` stays stable.
+ */
+export async function fetchClaimBanRows(): Promise<BanRow[]> {
+  const rows = await prisma.ban.findMany({
+    where: {
+      OR: [{ claimId: { not: null } }, { claimOnChainId: { not: null } }],
+    },
+    select: { chainId: true, claimId: true, claimOnChainId: true },
+  });
+
+  const needsOnChain = rows.filter(
+    (r): r is BanRow & { claimId: number } =>
+      r.claimId != null && r.claimOnChainId == null
+  );
+  if (needsOnChain.length === 0) {
+    return rows;
+  }
+
+  const claims = await prisma.claims.findMany({
+    where: {
+      OR: needsOnChain.map((b) => ({
+        chainId: b.chainId,
+        id: b.claimId,
+      })),
+    },
+    select: { id: true, chainId: true, onChainId: true },
+  });
+  const onChainByKey = new Map(
+    claims.map((c) => [`${c.chainId}:${c.id}`, c.onChainId] as const)
+  );
+
+  return rows.map((b) => {
+    if (b.claimId == null || b.claimOnChainId != null) {
+      return b;
+    }
+    const oc = onChainByKey.get(`${b.chainId}:${b.claimId}`);
+    return oc == null ? b : { ...b, claimOnChainId: oc };
+  });
+}
+
+export async function getClaimsNotBannedPrismaFilter(): Promise<Prisma.ClaimsWhereInput> {
+  const now = Date.now();
+  if (cached && cached.expires > now) {
+    return cached.filter;
+  }
+  const rows = await fetchClaimBanRows();
+  const filter = buildClaimsNotBannedWhereFromBanRows(rows);
+  cached = { filter, expires: now + CACHE_TTL_MS };
+  return filter;
+}

--- a/src/trpc/routers/accounts.ts
+++ b/src/trpc/routers/accounts.ts
@@ -6,6 +6,7 @@ import { addressSchema } from '../serverTypes';
 import { formatEther } from 'viem';
 import { fetchPrice } from '@/utils/utils';
 import { fetchImageMetadata } from './claims';
+import { getClaimsNotBannedPrismaFilter } from '@/trpc/claimBanFilter';
 
 export function scoreETH({
   earned,
@@ -54,18 +55,13 @@ export const accountsRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const items = await prisma.claims.findMany({
         where: {
           owner: input.address.toLowerCase(),
+          ...claimBanWhere,
+          ...(input.cursor ? { id: { lt: input.cursor } } : {}),
         },
-        ...(input.cursor
-          ? {
-              where: {
-                owner: input.address.toLowerCase(),
-                id: { lt: input.cursor },
-              },
-            }
-          : {}),
         orderBy: { id: 'desc' },
         take: input.limit,
       });
@@ -101,10 +97,11 @@ export const accountsRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const items = await prisma.claims.findMany({
         where: {
           issuer: input.address.toLowerCase(),
-          ban: { none: {} },
+          ...claimBanWhere,
           ...(input.cursor ? { id: { lt: input.cursor } } : {}),
         },
         orderBy: { id: 'desc' },
@@ -141,6 +138,7 @@ export const accountsRouter = {
     )
     .query(async ({ input }) => {
       const addr = input.address.toLowerCase();
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
 
       const [
         nfts,
@@ -150,7 +148,7 @@ export const accountsRouter = {
         completedClaims,
       ] = await Promise.all([
         prisma.claims.count({ where: { owner: addr } }),
-        prisma.claims.count({ where: { issuer: addr, ban: { none: {} } } }),
+        prisma.claims.count({ where: { issuer: addr, ...claimBanWhere } }),
         prisma.bounties.findMany({
           where: { issuer: addr, ban: { none: {} } },
           select: { id: true, inProgress: true, isCanceled: true },
@@ -165,7 +163,7 @@ export const accountsRouter = {
           },
         }),
         prisma.claims.count({
-          where: { issuer: addr, isAccepted: true, ban: { none: {} } },
+          where: { issuer: addr, isAccepted: true, ...claimBanWhere },
         }),
       ]);
 
@@ -221,6 +219,7 @@ export const accountsRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const [createdBounties, contributed] = await Promise.all([
         prisma.bounties
           .findMany({
@@ -232,9 +231,7 @@ export const accountsRouter = {
               claims: {
                 take: 1,
                 where: {
-                  ban: {
-                    none: {},
-                  },
+                  ...claimBanWhere,
                 },
               },
               participations: {
@@ -269,9 +266,7 @@ export const accountsRouter = {
                   claims: {
                     take: 1,
                     where: {
-                      ban: {
-                        none: {},
-                      },
+                      ...claimBanWhere,
                     },
                   },
                   participations: {
@@ -522,6 +517,7 @@ export const accountsRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const txs = await prisma.transactions.findMany({
         include: {
           bounty: {
@@ -544,10 +540,7 @@ export const accountsRouter = {
               none: {},
             },
           },
-          OR: [
-            { claimId: { equals: null } },
-            { claim: { is: { ban: { none: {} } } } },
-          ],
+          OR: [{ claimId: { equals: null } }, { claim: { is: claimBanWhere } }],
           ...(input.address
             ? {
                 address: input.address.toLowerCase(),

--- a/src/trpc/routers/admin.ts
+++ b/src/trpc/routers/admin.ts
@@ -6,6 +6,7 @@ import prisma from 'prisma/prisma';
 import { TRPCError } from '@trpc/server';
 import { getBanSignatureFirstLine } from '@/utils/utils';
 import { chains } from '@/utils/config';
+import { invalidateClaimBanFilterCache } from '@/trpc/claimBanFilter';
 
 export const adminRouter = {
   isAdmin: baseProcedure
@@ -73,6 +74,7 @@ export const adminRouter = {
           bannedBy: input.address.toLowerCase(),
         },
       });
+      invalidateClaimBanFilterCache();
     }),
 
   banClaim: baseProcedure
@@ -129,13 +131,22 @@ export const adminRouter = {
         });
       }
 
+      const claim = await prisma.claims.findUniqueOrThrow({
+        where: {
+          id_chainId: { id: input.id, chainId: input.chainId },
+        },
+        select: { onChainId: true },
+      });
+
       await prisma.ban.create({
         data: {
           chainId: input.chainId,
           bannedBy: input.address.toLowerCase(),
           claimId: input.id,
+          claimOnChainId: claim.onChainId,
         },
       });
+      invalidateClaimBanFilterCache();
     }),
 
   banComment: baseProcedure

--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -3,11 +3,13 @@ import { baseProcedure } from '../init';
 import prisma from 'prisma/prisma';
 import { addressSchema } from '../serverTypes';
 import { checkIsIssuer } from './admin';
+import { getClaimsNotBannedPrismaFilter } from '@/trpc/claimBanFilter';
 
 export const bountiesRouter = {
   fetch: baseProcedure
     .input(z.object({ id: z.number(), chainId: z.number() }))
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const bounty = await prisma.bounties.findUniqueOrThrow({
         where: {
           id_chainId: {
@@ -17,7 +19,7 @@ export const bountiesRouter = {
         include: {
           claims: {
             where: {
-              ban: { none: {} },
+              ...claimBanWhere,
             },
             select: { id: true },
             take: 1,
@@ -102,6 +104,7 @@ export const bountiesRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const sortByDate = input.sortType === 'date';
       const sortByValue = input.sortType === 'value';
 
@@ -141,9 +144,7 @@ export const bountiesRouter = {
                 claims: {
                   take: 1,
                   where: {
-                    ban: {
-                      none: {},
-                    },
+                    ...claimBanWhere,
                   },
                   orderBy: { isAccepted: 'desc' },
                 },
@@ -169,9 +170,7 @@ export const bountiesRouter = {
             claims: {
               take: 1,
               where: {
-                ban: {
-                  none: {},
-                },
+                ...claimBanWhere,
               },
               orderBy: { isAccepted: 'desc' },
             },
@@ -269,14 +268,13 @@ export const bountiesRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const items = await prisma.bounties.findMany({
         include: {
           claims: {
             take: 1,
             where: {
-              ban: {
-                none: {},
-              },
+              ...claimBanWhere,
             },
             orderBy: { isAccepted: 'desc' },
           },
@@ -361,12 +359,11 @@ export const bountiesRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       return await prisma.claims.count({
         where: {
           ...input,
-          ban: {
-            none: {},
-          },
+          ...claimBanWhere,
         },
       });
     }),
@@ -482,6 +479,7 @@ export const bountiesRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const q = input.keyword.trim();
 
       const items = await prisma.bounties.findMany({
@@ -489,9 +487,7 @@ export const bountiesRouter = {
           claims: {
             take: 1,
             where: {
-              ban: {
-                none: {},
-              },
+              ...claimBanWhere,
             },
           },
           participations: {

--- a/src/trpc/routers/claims.ts
+++ b/src/trpc/routers/claims.ts
@@ -3,20 +3,16 @@ import { baseProcedure } from '../init';
 import prisma from 'prisma/prisma';
 import axios from 'axios';
 import { tryCatchAsync } from '@/utils/utils';
+import { getClaimsNotBannedPrismaFilter } from '@/trpc/claimBanFilter';
 
 export const claimsRouter = {
   fetch: baseProcedure
     .input(z.object({ claimId: z.number(), chainId: z.number() }))
     .query(async ({ input }) => {
-      const claim = await prisma.claims.findUniqueOrThrow({
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
+      const claim = await prisma.claims.findFirstOrThrow({
         where: {
-          id_chainId: {
-            id: input.claimId,
-            chainId: input.chainId,
-          },
-          ban: {
-            none: {},
-          },
+          AND: [{ id: input.claimId, chainId: input.chainId }, claimBanWhere],
         },
       });
 
@@ -38,13 +34,12 @@ export const claimsRouter = {
       })
     )
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const items = await prisma.claims.findMany({
         where: {
           bountyId: input.bountyId,
           chainId: input.chainId,
-          ban: {
-            none: {},
-          },
+          ...claimBanWhere,
           ...(input.cursor
             ? { isAccepted: false, id: { lt: input.cursor } }
             : {}),
@@ -78,13 +73,12 @@ export const claimsRouter = {
   fetchAcceptedClaimByBountyId: baseProcedure
     .input(z.object({ bountyId: z.number(), chainId: z.number() }))
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const claim = await prisma.claims.findFirst({
         where: {
           bountyId: input.bountyId,
           chainId: input.chainId,
-          ban: {
-            none: {},
-          },
+          ...claimBanWhere,
           isAccepted: true,
         },
       });
@@ -104,6 +98,7 @@ export const claimsRouter = {
   fetchVotingClaimByBountyId: baseProcedure
     .input(z.object({ bountyId: z.number(), chainId: z.number() }))
     .query(async ({ input }) => {
+      const claimBanWhere = await getClaimsNotBannedPrismaFilter();
       const vote = await prisma.votes.findFirst({
         select: {
           claimId: true,
@@ -126,9 +121,7 @@ export const claimsRouter = {
         where: {
           id: vote.claimId,
           chainId: input.chainId,
-          ban: {
-            none: {},
-          },
+          ...claimBanWhere,
         },
       });
 


### PR DESCRIPTION
Claim rows use internal ids derived from indexer offsets; on_chain_id stays stable. Ban rows that only stored claim_id could stop matching after a reindex.

- Add claim_on_chain_id on Ban (migration 013) and reconcile rows (014)
- Centralize claim ban filter with runtime resolution + AND-of-NOTs Prisma shape
- Invalidate ban filter cache on bounty ban; fix NFT list query and account filters
- Combine claim lookup with ban filter using AND for Prisma 7 compatibility