### PR TITLE
Close Icon for Create claim card- fix

### DIFF
--- a/src/components/claims/FormClaim.tsx
+++ b/src/components/claims/FormClaim.tsx
@@ -308,8 +308,8 @@ export default function FormClaim({
               onClick={onClose}
               style={{
                 position: 'absolute',
-                right: 10,
-                top: 8,
+                right: 4,
+                top: 0,
                 color: 'white',
                 cursor: 'pointer',
                 padding: '8px',


### PR DESCRIPTION
i fixed the position of the close(X) icon. Inoticed it was oo close to other contents in the card. I made a simple and quick fix to it.