### PR TITLE
fix: bounty creation indexing message hidden behind Dialog overlay

### DIFF
--- a/src/components/global/Loading.tsx
+++ b/src/components/global/Loading.tsx
@@ -8,7 +8,7 @@ export default function Loading({
   status: string;
 }) {
   return (
-    <div className='fixed top-0 left-0 right-0 z-50'>
+    <div className='fixed top-0 left-0 right-0 z-[1401]'>
       <Transition
         show={open}
         enter='transition-transform duration-500 ease-out'
@@ -18,10 +18,10 @@ export default function Loading({
         leaveFrom='translate-y-0'
         leaveTo='-translate-y-full'
       >
-        <div className='bg-white/70 backdrop-blur-sm border-b border-gray-200/20 text-primary-700 px-6 py-3 flex items-center justify-center shadow-sm'>
+        <div className='bg-white/70 dark:bg-[#0d1b2e]/90 backdrop-blur-sm border-b border-gray-200/20 dark:border-white/10 px-6 py-3 flex items-center justify-center shadow-sm'>
           <div className='flex items-center space-x-4'>
-            <div className='animate-spin h-5 w-5 border-[2.5px] border-primary-600 border-t-transparent rounded-full' />
-            <span className='text-sm font-medium text-primary-600'>
+            <div className='animate-spin h-5 w-5 border-[2.5px] border-poidhBlue border-t-transparent rounded-full' />
+            <span className='text-sm font-medium text-poidhBlue dark:text-white'>
               {status}
             </span>
           </div>


### PR DESCRIPTION
## Summary

Fixes #1312

## Problem

The indexing progress bar ("Indexing Ns..." message) that appears during bounty creation is no longer visible. Users see no visual feedback during the indexing wait period after submitting a bounty.

## Root Cause

In commit `6e7b32f`, the `Loading` component was migrated from MUI `Backdrop` to headlessui `Transition`. The MUI Backdrop used `theme.zIndex.drawer + 1` (≈1300) as its z-index, which correctly rendered above MUI Dialog's backdrop (also ~1300). The new headlessui-based Loading uses `z-50` (z-index: 50), which is **below** MUI Dialog's default z-index (~1300).

Since `FormBounty` renders inside a MUI `Dialog`, the Dialog's backdrop overlay completely covers the Loading bar, making it invisible.

## Fix

- Raised Loading z-index from `z-50` to `z-[1401]` (above MUI modals at 1300 and custom modals at 1400)
- Added `dark:bg-\[#0d1b2e\]/90` and `dark:text-white` for proper dark mode visibility
- Replaced `text-primary-600` / `border-primary-600` with `text-poidhBlue` / `border-poidhBlue` for consistent styling with the app's design system

## Test

1. Create a new bounty
2. After wallet confirmation, the indexing progress bar should now appear at the top of the screen, visible above the Dialog overlay