### PR TITLE
fix: hide resolve vote button on completed/accepted bounties

### DIFF
--- a/src/components/bounty/Voting.tsx
+++ b/src/components/bounty/Voting.tsx
@@ -324,7 +324,7 @@ export default function Voting({
               </div>
             )}
 
-          {isVotingClosed && (
+          {isVotingClosed && !isAcceptedBounty && (
             <button
               className='w-full py-3 px-4 rounded-lg font-semibold transition-all duration-200 border border-blue-400/20 bg-gradient-to-r from-blue-500/70 to-blue-600/70 text-white hover:from-blue-500/85 hover:to-blue-600/85 hover:border-blue-400 active:scale-95 shadow-lg hover:shadow-blue-500/20'
               onClick={() => resolveVoteMutation.mutate()}


### PR DESCRIPTION
Fixes #1311

The resolve vote button was showing whenever voting was closed (deadline passed), even for bounties that were already accepted/resolved.

**Fix:** Added !isAcceptedBounty guard to the resolve vote button so it only appears when the voting period has ended AND the bounty has not yet been accepted.

**Before:** Completed bounties showed the 'Resolve vote' button even after being resolved.

**After:** The button is hidden once isAcceptedBounty is true.