### PR TITLE
fix: prevent crooked toggle slider on initial render

### DIFF
--- a/src/components/account/AccountInfo.tsx
+++ b/src/components/account/AccountInfo.tsx
@@ -115,10 +115,19 @@ export default function AccountInfo({ address }: { address: string }) {
   }, [currentSection]);
 
   useEffect(() => {
-    updateSliderPosition();
+    // Double-rAF ensures the browser has painted the tabs before we
+    // measure their positions, preventing the crooked-slider bug (#1257).
+    const rafId = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        updateSliderPosition();
+      });
+    });
 
     window.addEventListener('resize', updateSliderPosition);
-    return () => window.removeEventListener('resize', updateSliderPosition);
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', updateSliderPosition);
+    };
   }, [currentSection, updateSliderPosition, accountActivitiesCount.data]);
 
   const isOwnPage = (account.address ?? '').toLowerCase() === address;


### PR DESCRIPTION
Fixes #1257

The pill-shaped tab slider (NFTs/Bounties/Claims) sometimes rendered in a crooked position (~1 in 10 loads) because getBoundingClientRect() was called before the browser finished layout.

**Fix:** Added double-equestAnimationFrame to ensure the browser has painted the tabs before measuring their positions.