### PR TITLE
fix: force toast container to flush against top-right

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -236,6 +236,11 @@ button {
   color: white !important;
   backdrop-filter: blur(4px) !important;
 }
+.Toastify {
+  top: 0 !important;
+  right: 0 !important;
+  width: fit-content;
+}
 .dark .Toastify__toast-theme--light {
   background-color: rgba(13, 27, 46, 0.7) !important;
   border: 1px solid rgba(255, 255, 255, 0.3) !important;


### PR DESCRIPTION
Fixes #1180

Toast messages were appearing down the page instead of flush against the header. Added explicit 	op: 0 !important positioning to the .Toastify container to ensure consistent placement across all contexts including the Farcaster mini app.