### PR TITLE
fix: show clear error message when user lacks gas for claim

### DIFF
--- a/src/components/claims/FormClaim.tsx
+++ b/src/components/claims/FormClaim.tsx
@@ -207,7 +207,25 @@ export default function FormClaim({
     },
     onError: (error) => {
       setLoading({ isLoading: false });
-      toast.error('Failed to create claim: ' + error.message);
+      const msg = (error as Error)?.message ?? '';
+      if (
+        msg.toLowerCase().includes('insufficient funds') ||
+        msg.toLowerCase().includes('not enough balance') ||
+        msg.toLowerCase().includes('gas required exceeds allowance')
+      ) {
+        const chainLabel =
+          chain.slug === 'degen'
+            ? 'Degen Chain'
+            : chain.slug === 'arbitrum'
+              ? 'the Arbitrum network'
+              : 'the Base network';
+        const token = chain.slug === 'degen' ? 'DEGEN' : 'ETH';
+        toast.error(
+          `please add ${token} on ${chainLabel} to your wallet to complete this transaction`
+        );
+      } else {
+        toast.error('Failed to create claim: ' + msg);
+      }
     },
     onSettled: () => {
       utils.claims.fetchBountyClaims.refetch();


### PR DESCRIPTION
Fixes #986

When a user doesn't have enough gas to submit a claim, the app showed an incomprehensible technical error from viem/wagmi.

Fix: Detect insufficient-funds errors and show a clear, chain-specific message.