### PR TITLE
fix: use 'open' prop instead of deprecated 'show' for headlessui v2 Transition

### DIFF
--- a/src/components/global/Loading.tsx
+++ b/src/components/global/Loading.tsx
@@ -10,7 +10,7 @@ export default function Loading({
   return (
     <div className='fixed top-0 left-0 right-0 z-50'>
       <Transition
-        show={open}
+        open={open}
         enter='transition-transform duration-500 ease-out'
         enterFrom='-translate-y-full'
         enterTo='translate-y-0'


### PR DESCRIPTION
Fixes #1312

The Loading overlay used the headlessui v1 show prop on Transition, which is ignored in @headlessui/react v2 (^2.2.1). Changed to the v2 open prop so the bounty creation indexing message displays again.

Before: <Transition show={open}> (ignored in v2)
After: <Transition open={open}> (v2 API)