### PR TITLE
fix: show bounty indexing loading bar (#1312)

### DIFF
--- a/src/components/global/Loading.tsx
+++ b/src/components/global/Loading.tsx
@@ -8,7 +8,7 @@ export default function Loading({
   status: string;
 }) {
   return (
-    <div className='fixed top-0 left-0 right-0 z-50'>
+    <div className='fixed top-0 left-0 right-0 z-[2000] pointer-events-none'>
       <Transition
         show={open}
         enter='transition-transform duration-500 ease-out'


### PR DESCRIPTION
## Issue
Fixes https://github.com/picsoritdidnthappen/poidh-app/issues/1312

## Summary
- Restores visibility for the global loading/indexing banner while bounty creation is running inside modal/dialog flows.
- Raises the fixed banner above app dialogs/backdrops so `Indexing Ns...` feedback is not hidden behind overlays.
- Adds `pointer-events-none` so the banner layer cannot block dialog interactions while it is displayed.

## Tests run
- `pnpm exec eslint src/components/global/Loading.tsx` ✅
- `pnpm lint` ⚠️ fails on existing unrelated lint errors in `LatestClaimImages.tsx` and `ThemeContext.tsx`; this changed file passes ESLint.
- `pnpm typecheck` ⚠️ fails on existing unrelated project type errors / missing generated Prisma client; no errors reported for `Loading.tsx`.

## Risk notes
- Small styling-only change to the global Loading wrapper.
- Affects other global loading states too, but only by making them visible above overlays and non-interactive to clicks.