### PR TITLE
Fix value-sort pagination for equal bounty amounts

### DIFF
--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -3,6 +3,11 @@ import { baseProcedure } from '../init';
 import prisma from 'prisma/prisma';
 import { addressSchema } from '../serverTypes';
 import { checkIsIssuer } from './admin';
+import {
+  buildNextCursor,
+  buildValueSortCursorWhere,
+  valueSortOrderBy,
+} from './bountyPagination';
 
 export const bountiesRouter = {
   fetch: baseProcedure
@@ -97,6 +102,8 @@ export const bountiesRouter = {
             createdAt: z.coerce.number(),
             amountSort: z.number(),
             dates: z.array(z.number()),
+            bountyId: z.number().optional(),
+            chainId: z.number().optional(),
           })
           .nullish(),
       })
@@ -131,9 +138,7 @@ export const bountiesRouter = {
                 : {}),
             },
 
-            ...(input.cursor
-              ? { amountSort: { lt: input.cursor.amountSort } }
-              : {}),
+            ...buildValueSortCursorWhere(input.cursor),
           },
           select: {
             bounty: {
@@ -155,7 +160,7 @@ export const bountiesRouter = {
             },
             amountSort: true,
           },
-          orderBy: { amountSort: 'desc' },
+          orderBy: valueSortOrderBy(),
           take: input.limit,
         });
 
@@ -227,26 +232,11 @@ export const bountiesRouter = {
         }));
       }
 
-      let nextCursor:
-        | {
-            createdAt: number;
-            amountSort: number;
-            dates: number[];
-          }
-        | undefined = undefined;
-
-      if (items.length === input.limit) {
-        const last = items[items.length - 1];
-
-        nextCursor = {
-          createdAt: last.createdAt.toNumber(),
-          amountSort: last.amountSort,
-          dates: [
-            ...(input.cursor?.dates ?? []),
-            ...items.map((item) => Number(item?.createdAt)),
-          ],
-        };
-      }
+      const nextCursor = buildNextCursor(
+        items,
+        input.limit,
+        input.cursor?.dates
+      );
 
       return {
         items: items.map(({ claims, participations, ...bounty }) => ({

--- a/src/trpc/routers/bountyPagination.test.ts
+++ b/src/trpc/routers/bountyPagination.test.ts
@@ -1,0 +1,76 @@
+import {
+  buildNextCursor,
+  buildValueSortCursorWhere,
+  valueSortOrderBy,
+} from './bountyPagination';
+
+function decimal(value: number) {
+  return { toNumber: () => value };
+}
+
+describe('bounty pagination', () => {
+  it('uses a stable value-sort tie breaker so equal-value bounties are not skipped', () => {
+    expect(
+      buildValueSortCursorWhere({
+        createdAt: 1_770_000_000,
+        amountSort: 50,
+        bountyId: 215,
+        chainId: 42161,
+        dates: [1_770_000_000],
+      })
+    ).toEqual({
+      OR: [
+        { amountSort: { lt: 50 } },
+        { amountSort: 50, bountyId: { lt: 215 } },
+        { amountSort: 50, bountyId: 215, chainId: { lt: 42161 } },
+      ],
+    });
+  });
+
+  it('preserves the previous cursor shape for older clients', () => {
+    expect(
+      buildValueSortCursorWhere({
+        createdAt: 1_770_000_000,
+        amountSort: 50,
+        dates: [1_770_000_000],
+      })
+    ).toEqual({ amountSort: { lt: 50 } });
+  });
+
+  it('orders value-sort pages by amount then stable bounty identity', () => {
+    expect(valueSortOrderBy()).toEqual([
+      { amountSort: 'desc' },
+      { bountyId: 'desc' },
+      { chainId: 'desc' },
+    ]);
+  });
+
+  it('returns a cursor with bounty identity for the next value-sort page', () => {
+    const cursor = buildNextCursor(
+      [
+        {
+          id: 216,
+          chainId: 42161,
+          createdAt: decimal(1_770_000_001),
+          amountSort: 50,
+        },
+        {
+          id: 215,
+          chainId: 42161,
+          createdAt: decimal(1_770_000_000),
+          amountSort: 50,
+        },
+      ],
+      2,
+      [1_769_999_999]
+    );
+
+    expect(cursor).toEqual({
+      createdAt: 1_770_000_000,
+      amountSort: 50,
+      bountyId: 215,
+      chainId: 42161,
+      dates: [1_769_999_999, 1_770_000_001, 1_770_000_000],
+    });
+  });
+});

--- a/src/trpc/routers/bountyPagination.ts
+++ b/src/trpc/routers/bountyPagination.ts
@@ -1,0 +1,66 @@
+export type BountyCursor = {
+  createdAt: number;
+  amountSort: number;
+  dates: number[];
+  bountyId?: number;
+  chainId?: number;
+};
+
+export type BountyListItem = {
+  id: number;
+  chainId: number;
+  createdAt: { toNumber: () => number };
+  amountSort: number;
+};
+
+export function buildValueSortCursorWhere(cursor: BountyCursor | null | undefined) {
+  if (!cursor) return {};
+
+  if (cursor.bountyId === undefined || cursor.chainId === undefined) {
+    return { amountSort: { lt: cursor.amountSort } };
+  }
+
+  return {
+    OR: [
+      { amountSort: { lt: cursor.amountSort } },
+      {
+        amountSort: cursor.amountSort,
+        bountyId: { lt: cursor.bountyId },
+      },
+      {
+        amountSort: cursor.amountSort,
+        bountyId: cursor.bountyId,
+        chainId: { lt: cursor.chainId },
+      },
+    ],
+  };
+}
+
+export function valueSortOrderBy() {
+  return [
+    { amountSort: 'desc' as const },
+    { bountyId: 'desc' as const },
+    { chainId: 'desc' as const },
+  ];
+}
+
+export function buildNextCursor(
+  items: BountyListItem[],
+  limit: number,
+  previousDates: number[] = []
+): BountyCursor | undefined {
+  if (items.length !== limit) return undefined;
+
+  const last = items[items.length - 1];
+
+  return {
+    createdAt: last.createdAt.toNumber(),
+    amountSort: last.amountSort,
+    bountyId: last.id,
+    chainId: last.chainId,
+    dates: [
+      ...previousDates,
+      ...items.map((item) => item.createdAt.toNumber()),
+    ],
+  };
+}


### PR DESCRIPTION
Fixes #1216.

## Summary
- Add stable value-sort cursor ordering by `amountSort`, `bountyId`, and `chainId` so bounties with the same USD value are not skipped between pages.
- Preserve the existing older cursor shape for clients that do not send bounty identity fields.
- Add focused pure tests for the cursor where clause, ordering, and next-cursor identity.

## Why this targets the issue
The missing Arbitrum bounties are both `$50` items. The previous value-sort cursor only requested rows with `amountSort < cursor.amountSort`, so remaining `$50` rows after a page boundary could be skipped. Date sorting does not use that value cursor, which matches the issue report.

## Verification
- `npm test -- --runTestsByPath src/trpc/routers/bountyPagination.test.ts --watch=false`
- `npx tsc --noEmit --target es2020 --module commonjs --moduleResolution node --skipLibCheck src/trpc/routers/bountyPagination.ts`

Note: Full `npm run typecheck` is blocked in this local clone by existing generated Prisma/client and unrelated repository type issues.