### PR TITLE
Make bounty text markdown friendly

### DIFF
--- a/src/components/global/TextWithLinks.tsx
+++ b/src/components/global/TextWithLinks.tsx
@@ -1,12 +1,16 @@
-export default function TextWithLinks({ children }: { children: string }) {
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
-  const parts = children.split(urlRegex);
+import React from 'react';
 
-  return parts.map((part, index) => {
+const urlRegex = /(https?:\/\/[^\s]+)/g;
+const tokenRegex = /(https?:\/\/[^\s]+|\*\*[^*]+\*\*|__[^_]+__|`[^`]+`)/g;
+
+function renderInlineMarkdown(text: string, keyPrefix: string) {
+  return text.split(tokenRegex).map((part, index) => {
+    const key = `${keyPrefix}-${index}`;
+
     if (part.match(urlRegex)) {
       return (
         <a
-          key={index}
+          key={key}
           href={part}
           target='_blank'
           rel='noopener noreferrer'
@@ -16,6 +20,52 @@ export default function TextWithLinks({ children }: { children: string }) {
         </a>
       );
     }
+
+    if (
+      (part.startsWith('**') && part.endsWith('**')) ||
+      (part.startsWith('__') && part.endsWith('__'))
+    ) {
+      return <strong key={key}>{part.slice(2, -2)}</strong>;
+    }
+
+    if (part.startsWith('`') && part.endsWith('`')) {
+      return (
+        <code key={key} className='rounded bg-white/10 px-1 py-0.5'>
+          {part.slice(1, -1)}
+        </code>
+      );
+    }
+
     return part;
+  });
+}
+
+export default function TextWithLinks({ children }: { children: string }) {
+  return children.split(/\n/).flatMap((line, lineIndex, lines) => {
+    const renderedLine: React.ReactNode[] = [];
+    const trimmed = line.trimStart();
+    const isBullet = trimmed.startsWith('- ') || trimmed.startsWith('* ');
+    const content = isBullet ? trimmed.slice(2) : line;
+
+    if (isBullet) {
+      renderedLine.push(
+        <React.Fragment key={`bullet-${lineIndex}`}>
+          <span aria-hidden='true'>• </span>
+          {renderInlineMarkdown(content, `line-${lineIndex}`)}
+        </React.Fragment>
+      );
+    } else {
+      renderedLine.push(
+        <React.Fragment key={`line-${lineIndex}`}>
+          {renderInlineMarkdown(content, `line-${lineIndex}`)}
+        </React.Fragment>
+      );
+    }
+
+    if (lineIndex < lines.length - 1) {
+      renderedLine.push(<br key={`br-${lineIndex}`} />);
+    }
+
+    return renderedLine;
   });
 }


### PR DESCRIPTION
## Summary
- Render basic markdown-friendly formatting in shared bounty/claim/comment text (`**bold**`, `__bold__`, inline `code`, and `-`/`*` bullet lines).
- Preserve the existing URL auto-linking behavior without adding dependencies or using raw HTML rendering.

## Verification
- `npx eslint src/components/global/TextWithLinks.tsx` ✅
- `npm run typecheck` attempted after `npm install --legacy-peer-deps`; it fails on existing baseline repository issues unrelated to this change: dependency TypeScript target errors in `node_modules/viem/node_modules/ox`, missing generated `generated/prisma/client`, and existing implicit-any errors across multiple files.

Closes #1349