### PR TITLE
fix: redirect to profile after bounty cancellation

### DIFF
--- a/src/components/bounty/BountyInfo.tsx
+++ b/src/components/bounty/BountyInfo.tsx
@@ -165,6 +165,7 @@ export default function BountyInfo({
     onSuccess: () => {
       setLoading({ isLoading: false });
       toast.success('Bounty canceled');
+      router.push('/profile');
     },
     onError: (error) => {
       setLoading({ isLoading: false });


### PR DESCRIPTION
Closes #1365

Adds router.push('/profile') after successful bounty cancellation.