### PR TITLE
fix: redirect to profile after bounty cancellation

### DIFF
--- a/src/components/bounty/BountyInfo.tsx
+++ b/src/components/bounty/BountyInfo.tsx
@@ -165,6 +165,7 @@ export default function BountyInfo({
     onSuccess: () => {
       setLoading({ isLoading: false });
       toast.success('Bounty canceled');
+      window.location.href = '/profile';
     },
     onError: (error) => {
       setLoading({ isLoading: false });


### PR DESCRIPTION
Closes #1365

Redirects user to profile page after successful bounty cancellation using window.location.href.