### PR TITLE
fix: show thank you message for bounty owners after voting

### DIFF
--- a/src/components/bounty/Voting.tsx
+++ b/src/components/bounty/Voting.tsx
@@ -312,7 +312,7 @@ export default function Voting({
             </div>
           )}
 
-          {isBountyContributor &&
+          {(isBountyContributor || isBountyOwner) &&
             userCanVote.data === false &&
             !isAcceptedBounty && (
               <div className='p-4 rounded-lg border text-center'>


### PR DESCRIPTION
Closes #1219

Bounty owners who are not contributors would not see the thank-you message after voting. Fixed by adding isBountyOwner to the conditional check.