### PR TITLE
fix: prevent degen placeholder truncation in Rainbow browser (#1092)

### DIFF
--- a/src/components/bounty/FormJoinBounty.tsx
+++ b/src/components/bounty/FormJoinBounty.tsx
@@ -166,10 +166,13 @@ export default function FormJoinBounty({
                   value={amount}
                   onChange={handleAmountChange}
                   placeholder={`amount in ${chain.currency}`}
-                  className='border bg-transparent border-[#D1ECFF] py-2 px-2 rounded-md w-full pr-28 placeholder:text-slate-400 whitespace-nowrap'
+                  className={cn(
+                    'border bg-transparent border-[#D1ECFF] py-2 px-2 rounded-md w-full placeholder:text-slate-400 text-sm sm:text-base whitespace-nowrap text-ellipsis overflow-hidden',
+                    usdPerToken !== null ? 'pr-24' : 'pr-3'
+                  )}
                 />
                 {usdPerToken !== null && (
-                  <span className='absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 font-semibold pointer-events-none max-w-[120px] truncate text-right'>
+                  <span className='absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 font-semibold pointer-events-none max-w-[88px] truncate text-right text-sm sm:text-base'>
                     (${formatAmountShort({ amount: usdPerToken })})
                   </span>
                 )}


### PR DESCRIPTION
Closes #1092