### PR TITLE
[codex] Fix value-sorted bounty pagination

### DIFF
--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -3,6 +3,11 @@ import { baseProcedure } from '../init';
 import prisma from 'prisma/prisma';
 import { addressSchema } from '../serverTypes';
 import { checkIsIssuer } from './admin';
+import {
+  nextBountyCursor,
+  valueSortCursorWhere,
+  valueSortOrderBy,
+} from './bountyPagination';
 
 export const bountiesRouter = {
   fetch: baseProcedure
@@ -97,6 +102,8 @@ export const bountiesRouter = {
             createdAt: z.coerce.number(),
             amountSort: z.number(),
             dates: z.array(z.number()),
+            bountyId: z.number().optional(),
+            chainId: z.number().optional(),
           })
           .nullish(),
       })
@@ -131,9 +138,7 @@ export const bountiesRouter = {
                 : {}),
             },
 
-            ...(input.cursor
-              ? { amountSort: { lt: input.cursor.amountSort } }
-              : {}),
+            ...valueSortCursorWhere(input.cursor),
           },
           select: {
             bounty: {
@@ -155,7 +160,7 @@ export const bountiesRouter = {
             },
             amountSort: true,
           },
-          orderBy: { amountSort: 'desc' },
+          orderBy: valueSortOrderBy(),
           take: input.limit,
         });
 
@@ -227,26 +232,11 @@ export const bountiesRouter = {
         }));
       }
 
-      let nextCursor:
-        | {
-            createdAt: number;
-            amountSort: number;
-            dates: number[];
-          }
-        | undefined = undefined;
-
-      if (items.length === input.limit) {
-        const last = items[items.length - 1];
-
-        nextCursor = {
-          createdAt: last.createdAt.toNumber(),
-          amountSort: last.amountSort,
-          dates: [
-            ...(input.cursor?.dates ?? []),
-            ...items.map((item) => Number(item?.createdAt)),
-          ],
-        };
-      }
+      const nextCursor = nextBountyCursor(
+        items,
+        input.limit,
+        input.cursor?.dates
+      );
 
       return {
         items: items.map(({ claims, participations, ...bounty }) => ({

--- a/src/trpc/routers/bountyPagination.test.ts
+++ b/src/trpc/routers/bountyPagination.test.ts
@@ -1,0 +1,92 @@
+import {
+  nextBountyCursor,
+  valueSortCursorWhere,
+  valueSortOrderBy,
+} from './bountyPagination';
+
+function decimal(value: number) {
+  return { toNumber: () => value };
+}
+
+describe('bounty pagination', () => {
+  it('orders value pages by amount and stable bounty identity', () => {
+    expect(valueSortOrderBy()).toEqual([
+      { amountSort: 'desc' },
+      { bountyId: 'desc' },
+      { chainId: 'desc' },
+    ]);
+  });
+
+  it('keeps equal-value bounties after the cursor visible', () => {
+    expect(
+      valueSortCursorWhere({
+        createdAt: 1_770_000_000,
+        amountSort: 50,
+        bountyId: 215,
+        chainId: 42161,
+        dates: [1_770_000_000],
+      })
+    ).toEqual({
+      OR: [
+        { amountSort: { lt: 50 } },
+        { amountSort: 50, bountyId: { lt: 215 } },
+        { amountSort: 50, bountyId: 215, chainId: { lt: 42161 } },
+      ],
+    });
+  });
+
+  it('preserves older cursors that do not include bounty identity', () => {
+    expect(
+      valueSortCursorWhere({
+        createdAt: 1_770_000_000,
+        amountSort: 50,
+        dates: [1_770_000_000],
+      })
+    ).toEqual({ amountSort: { lt: 50 } });
+  });
+
+  it('returns a cursor with bounty identity for the next page', () => {
+    expect(
+      nextBountyCursor(
+        [
+          {
+            id: 216,
+            chainId: 42161,
+            createdAt: decimal(1_770_000_001),
+            amountSort: 50,
+          },
+          {
+            id: 215,
+            chainId: 42161,
+            createdAt: decimal(1_770_000_000),
+            amountSort: 50,
+          },
+        ],
+        2,
+        [1_769_999_999]
+      )
+    ).toEqual({
+      createdAt: 1_770_000_000,
+      amountSort: 50,
+      bountyId: 215,
+      chainId: 42161,
+      dates: [1_769_999_999, 1_770_000_001, 1_770_000_000],
+    });
+  });
+
+  it('does not return a cursor for the final page', () => {
+    expect(
+      nextBountyCursor(
+        [
+          {
+            id: 215,
+            chainId: 42161,
+            createdAt: decimal(1_770_000_000),
+            amountSort: 50,
+          },
+        ],
+        2
+      )
+    ).toBeUndefined();
+  });
+});

--- a/src/trpc/routers/bountyPagination.ts
+++ b/src/trpc/routers/bountyPagination.ts
@@ -1,0 +1,68 @@
+export type BountyCursor = {
+  createdAt: number;
+  amountSort: number;
+  dates: number[];
+  bountyId?: number;
+  chainId?: number;
+};
+
+type BountyCursorInput = Partial<BountyCursor>;
+
+export type BountyListItem = {
+  id: number;
+  chainId: number;
+  createdAt: { toNumber: () => number };
+  amountSort: number;
+};
+
+export function valueSortOrderBy() {
+  return [
+    { amountSort: 'desc' as const },
+    { bountyId: 'desc' as const },
+    { chainId: 'desc' as const },
+  ];
+}
+
+export function valueSortCursorWhere(
+  cursor: BountyCursorInput | null | undefined
+) {
+  if (!cursor) return {};
+  if (cursor.amountSort === undefined) return {};
+
+  if (cursor.bountyId === undefined || cursor.chainId === undefined) {
+    return { amountSort: { lt: cursor.amountSort } };
+  }
+
+  return {
+    OR: [
+      { amountSort: { lt: cursor.amountSort } },
+      { amountSort: cursor.amountSort, bountyId: { lt: cursor.bountyId } },
+      {
+        amountSort: cursor.amountSort,
+        bountyId: cursor.bountyId,
+        chainId: { lt: cursor.chainId },
+      },
+    ],
+  };
+}
+
+export function nextBountyCursor(
+  items: BountyListItem[],
+  limit: number,
+  previousDates: number[] = []
+): BountyCursor | undefined {
+  if (items.length !== limit) return undefined;
+
+  const last = items[items.length - 1];
+
+  return {
+    createdAt: last.createdAt.toNumber(),
+    amountSort: last.amountSort,
+    bountyId: last.id,
+    chainId: last.chainId,
+    dates: [
+      ...previousDates,
+      ...items.map((item) => item.createdAt.toNumber()),
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- Fix value-sorted bounty pagination by adding stable tie-breakers after `amountSort`.
- Include bounty identity in the next cursor so equal-value bounties after a page boundary stay visible.
- Add focused tests for value sort ordering, cursor filtering, legacy cursor fallback, and final-page cursor behavior.

## Root cause
The value-sort cursor only filtered with `amountSort < cursor.amountSort`. If a page ended on a $50 bounty, the next query excluded other $50 bounties instead of continuing through the equal-value set. That matches the issue where bounties #213 and #215 can be reached by date sorting but not by default value sorting.

Fixes #1216

## Validation
- `jest --runTestsByPath src/trpc/routers/bountyPagination.test.ts --watch=false`
- `prettier --check src/trpc/routers/bounties.ts src/trpc/routers/bountyPagination.ts src/trpc/routers/bountyPagination.test.ts`
- `eslint src/trpc/routers/bounties.ts src/trpc/routers/bountyPagination.ts src/trpc/routers/bountyPagination.test.ts` (0 errors; existing warnings in `bounties.ts`)
- `tsc --noEmit --incremental false`
- `git diff --check`

## Bounty payout
If accepted for the bounty, BTC payout is preferred:
`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

If this bounty requires a different supported payout route, I can provide one after acceptance.