### PR TITLE
fix: show indexing message and wait before reload on submit claim for vote (#457)

### DIFF
--- a/src/components/claims/ClaimItem.tsx
+++ b/src/components/claims/ClaimItem.tsx
@@ -121,15 +121,33 @@ export default function ClaimItem({
         args: [BigInt(bounty.data.onChainId), BigInt(claim.onChainId)],
         chainId: pollingChainId ?? chain.id,
       });
+
+      for (let i = 0; i < 60; i++) {
+        setLoading({ isLoading: true, status: `Indexing ${i}s...` });
+        const submitted = await trpcClient.claims.isSubmittedForVote.query({
+          id: Number(claim.id),
+          chainId: pollingChainId ?? chain.id,
+        });
+        if (submitted) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+      }
+
+      throw new Error('Failed to submit claim for vote');
     },
     onSuccess: () => {
+      setLoading({ isLoading: false });
       toast.success('Claim submitted for vote successfully');
       window.location.reload();
     },
     onError: (error) => {
+      setLoading({ isLoading: false });
       toast.error('Failed to submit claim for vote: ' + error.message);
     },
     onSettled: () => {
+      utils.claims.fetchBountyClaims.refetch();
+      setPollingChainId(null);
       setLoading({ isLoading: false, status: '' });
     },
   });

--- a/src/trpc/routers/claims.ts
+++ b/src/trpc/routers/claims.ts
@@ -170,6 +170,19 @@ export const claimsRouter = {
         },
       });
     }),
+
+  isSubmittedForVote: baseProcedure
+    .input(z.object({ chainId: z.number(), id: z.number() }))
+    .query(async ({ input }) => {
+      return prisma.votes.findFirst({
+        where: {
+          claimId: input.id,
+          chainId: input.chainId,
+        },
+        orderBy: { round: 'desc' },
+        take: 1,
+      });
+    }),
 };
 
 export async function fetchImageMetadata(url: string) {


### PR DESCRIPTION
## Summary

Fixes #457.

When a bounty owner clicked **propose winner** (submit claim for vote), `submitForVoteMutation` called `window.location.reload()` immediately after the tx was mined. The indexer had not caught up yet, so the reloaded page showed the same pre-vote state — the user had no feedback that the claim was submitted for vote.

## Changes

- **`src/trpc/routers/claims.ts`** — add `claims.isSubmittedForVote` query that looks up the latest `Votes` row for a given `claimId` + `chainId`. Mirrors the existing `claims.isAccepted` helper used by the accept-claim flow.
- **`src/components/claims/ClaimItem.tsx`** — after `submitClaimForVote` returns, poll `isSubmittedForVote` once per second (up to 60s) while showing the `Indexing Xs...` loading overlay, exactly like `acceptClaimMutation` already does. Only once indexing is confirmed do we reload the page, so the voting UI is populated on refresh. Also refetch `fetchBountyClaims` and reset `pollingChainId` in `onSettled`.

## Test plan

- As a bounty owner on a multiplayer bounty, open a claim and tap **propose winner**.
- Verify the `Indexing Xs...` overlay appears (instead of an instant reload).
- After indexing completes, the page reloads and the voting breakdown is visible.
- On error (e.g. tx reverted), verify the loading overlay is dismissed and a toast is shown.
