### PR TITLE
Integrate .gwei names (addresses #1399)

### DIFF
--- a/migrations/014_add_gwei_users_extra_table.sql
+++ b/migrations/014_add_gwei_users_extra_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE :schema."UsersExtra"
+ADD COLUMN "gwei" TEXT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,7 @@ model UsersExtra {
   ens          String?
   degenName    String?  @map("degen_name")
   wei          String?
+  gwei         String?
   farcasterTag       String?   @map("farcaster_tag")
   farcasterFid       Int?      @map("farcaster_fid")
   twitterTag         String?   @map("twitter_tag")

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -16,13 +16,13 @@ const formatUserName = (name: string) =>
   name.length >= 12 ? `${name.slice(0, 6)}…${name.slice(-5)}` : name;
 
 function ResolvedAddressCell({ address }: { address: string }) {
-  const weiOrEnsOrDegenName = trpc.web3.fetchWeiOrEnsOrDegenName.useQuery({
+  const humanReadableName = trpc.web3.fetchHumanReadableName.useQuery({
     address,
   });
   return (
     <span className='relative'>
       {formatUserName(
-        weiOrEnsOrDegenName.data?.slice(0, 12) ?? address.slice(0, 7)
+        humanReadableName.data?.slice(0, 12) ?? address.slice(0, 7)
       )}
     </span>
   );
@@ -34,6 +34,7 @@ function getDisplayName(user: UserData): string {
   }
 
   if (user.farcasterTag) return formatUserName(user.farcasterTag);
+  if (user.gwei) return formatUserName(user.gwei.slice(0, 12));
   if (user.wei) return formatUserName(user.wei.slice(0, 12));
   if (user.ens) return formatUserName(user.ens.slice(0, 12));
   if (user.degenName) return formatUserName(user.degenName.slice(0, 12));

--- a/src/components/account/UserList.tsx
+++ b/src/components/account/UserList.tsx
@@ -8,12 +8,14 @@ import InfiniteScroll from 'react-infinite-scroller';
 
 function getDisplayName(user: {
   farcaster_tag?: string | null;
+  gwei?: string | null;
   wei?: string | null;
   ens?: string | null;
   degen_name?: string | null;
   address?: string;
 }): string {
   if (user.farcaster_tag) return user.farcaster_tag;
+  if (user.gwei) return user.gwei;
   if (user.wei) return user.wei;
   if (user.ens) return user.ens;
   if (user.degen_name) return user.degen_name;

--- a/src/components/global/DisplayAddress.tsx
+++ b/src/components/global/DisplayAddress.tsx
@@ -15,7 +15,7 @@ export default function DisplayAddress({
   const userQuery = trpc.neynar.usersData.useQuery({
     addresses: [address],
   });
-  const weiOrEnsOrDegenName = trpc.web3.fetchWeiOrEnsOrDegenName.useQuery({
+  const humanReadableName = trpc.web3.fetchHumanReadableName.useQuery({
     address,
   });
 
@@ -50,10 +50,10 @@ export default function DisplayAddress({
           ? formatWalletAddress(address)
           : user?.farcasterTag
           ? user.farcasterTag
-          : weiOrEnsOrDegenName.isLoading
+          : humanReadableName.isLoading
           ? formatWalletAddress(address)
-          : weiOrEnsOrDegenName.data
-          ? weiOrEnsOrDegenName.data
+          : humanReadableName.data
+          ? humanReadableName.data
           : formatWalletAddress(address)}
       </Link>
     </span>

--- a/src/components/og/BountyPreviewCard.tsx
+++ b/src/components/og/BountyPreviewCard.tsx
@@ -17,7 +17,7 @@ export type FarcasterUser = {
   pfp_url: string;
 };
 
-async function resolveWeiOrEnsOrDegenNames(
+async function resolveHumanReadableNames(
   addresses: string[]
 ): Promise<{ [address: string]: string }> {
   const results: { [address: string]: string } = {};
@@ -26,7 +26,7 @@ async function resolveWeiOrEnsOrDegenNames(
       const res = await fetch(
         `${
           process.env.NEXT_PUBLIC_APP_URL
-        }/api/trpc/web3.fetchWeiOrEnsOrDegenName?input=${encodeURIComponent(
+        }/api/trpc/web3.fetchHumanReadableName?input=${encodeURIComponent(
           JSON.stringify({ json: { address: addr } })
         )}`
       );
@@ -57,7 +57,7 @@ export default async function BountyPreviewCard({
   const addressesWithoutFarcaster = bountyData.participants.filter(
     (p) => !farcasterParticipants[p]?.[0]?.username
   );
-  const resolvedNames = await resolveWeiOrEnsOrDegenNames(
+  const resolvedNames = await resolveHumanReadableNames(
     addressesWithoutFarcaster
   );
 

--- a/src/constant/abi/abiGweiNames.ts
+++ b/src/constant/abi/abiGweiNames.ts
@@ -1,0 +1,23 @@
+const GweiNamesAbi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'addr',
+        type: 'address',
+      },
+    ],
+    name: 'reverseResolve',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+export default GweiNamesAbi;

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -2,3 +2,4 @@ export { default as ABI } from './abi/abi';
 export { default as DEGENNAMERESABI } from './abi/abiDegenNameRes';
 export { default as NFTABI } from './abi/abiNFT';
 export { default as WEINAMESABI } from './abi/abiWeiNames';
+export { default as GWEINAMESABI } from './abi/abiGweiNames';

--- a/src/trpc/routers/users.ts
+++ b/src/trpc/routers/users.ts
@@ -28,6 +28,7 @@ export const usersRouter = {
         ens: userExtra?.ens ?? null,
         degenName: userExtra?.degenName ?? null,
         wei: userExtra?.wei ?? null,
+        gwei: userExtra?.gwei ?? null,
         farcasterTag: userExtra?.farcasterTag ?? null,
         farcasterFid: userExtra?.farcasterFid ?? null,
         twitterTag: userExtra?.twitterTag ?? null,
@@ -113,6 +114,7 @@ export const usersRouter = {
             ux."ens",
             ux."degen_name",
             ux."wei",
+            ux."gwei",
             ux."farcaster_tag",
             COALESCE(c.bounty_count, 0) AS bounty_count
           FROM "Users" u
@@ -124,6 +126,7 @@ export const usersRouter = {
             u."address" NOT IN (${Prisma.join(ignoreAddresses)})
             AND CASE
               WHEN ux."farcaster_tag" IS NOT NULL THEN ux."farcaster_tag" ILIKE ${search}
+              WHEN ux."gwei"         IS NOT NULL THEN ux."gwei"         ILIKE ${search}
               WHEN ux."wei"          IS NOT NULL THEN ux."wei"          ILIKE ${search}
               WHEN ux."ens"          IS NOT NULL THEN ux."ens"          ILIKE ${search}
               WHEN ux."degen_name"   IS NOT NULL THEN ux."degen_name"   ILIKE ${search}

--- a/src/trpc/routers/web3.ts
+++ b/src/trpc/routers/web3.ts
@@ -2,7 +2,7 @@ import prisma from 'prisma/prisma';
 import { baseProcedure } from '../init';
 import { z } from 'zod';
 import { mainnetPublicClient, degenPublicClient } from '@/utils/publicClients';
-import { DEGENNAMERESABI, WEINAMESABI } from '@/constant';
+import { DEGENNAMERESABI, WEINAMESABI, GWEINAMESABI } from '@/constant';
 
 export const web3Router = {
   fetchPrice: baseProcedure
@@ -30,7 +30,7 @@ export const web3Router = {
         : Number(rate.ethUsd);
     }),
 
-  fetchWeiOrEnsOrDegenName: baseProcedure
+  fetchHumanReadableName: baseProcedure
     .input(
       z.object({
         address: z.string(),
@@ -44,6 +44,35 @@ export const web3Router = {
           address: input.address.toLowerCase(),
         },
       });
+
+      if (!user || !user.gwei || user.lastUpdated < tenDaysAgo) {
+        try {
+          const gweiName = await mainnetPublicClient.readContract({
+            abi: GWEINAMESABI,
+            address: '0x9D51D507BC7264d4fE8Ad1cf7Fe191933A0a81d6',
+            functionName: 'reverseResolve',
+            args: [input.address as `0x${string}`],
+          });
+
+          if (gweiName) {
+            await prisma.usersExtra.upsert({
+              where: { address: input.address.toLowerCase() },
+              update: { gwei: gweiName, lastUpdated: new Date() },
+              create: {
+                address: input.address.toLowerCase(),
+                gwei: gweiName,
+                lastUpdated: new Date(),
+              },
+            });
+
+            return gweiName;
+          }
+        } catch {}
+      }
+
+      if (user?.gwei) {
+        return user.gwei;
+      }
 
       if (!user || !user.wei || user.lastUpdated < tenDaysAgo) {
         try {

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -67,6 +67,9 @@ export function getDisplayUsername(
   } else if (platform === 'twitter' && user?.twitterTag) {
     return `@${user.twitterTag}`;
   }
+  if (user?.gwei) {
+    return user.gwei;
+  }
   if (user?.wei) {
     return user.wei;
   }


### PR DESCRIPTION
## What

Integrates `.gwei` domain resolution as mentioned in #1399. I matched this to the existing `.wei` integration in #1197, since `.gwei` is a fork.

## Changes

  - **Resolution** (`src/trpc/routers/web3.ts`): adds a gwei `reverseResolve` lookup against the gwei NameNFT contract (`0x9D51D507BC7264d4fE8Ad1cf7Fe191933A0a81d6`, Ethereum mainnet) via the existing `mainnetPublicClient`, with the same 10-day cache + upsert as the other providers. gwei is checked first (gwei → wei → ENS → degen).
  - **Data**: new nullable `gwei` column on `UsersExtra` (`migrations/014_add_gwei_users_extra_table.sql` + Prisma schema).
  - **ABI**: new `abiGweiNames.ts`.
  - **Surfaces**: gwei surfaced through the user object (`users.ts`) and the display-name priority (farcaster → resolved name) in the leaderboard, account list, share text, and `DisplayAddress`.
  - **Rename**: tRPC `fetchWeiOrEnsOrDegenName` → `fetchHumanReadableName` (provider-agnostic; all call sites updated).

## Testing

Verified locally against live mainnet data — e.g. `/account/0xC04689227Fa24785609B1174698DBe481437f1A3` → `donnoh.gwei` renders on the account page, resolving gwei-first and caching to `UsersExtra`.