### PR TITLE
Fix payout button offering acceptClaim on bounties where the contract always reverts

### DIFF
--- a/src/components/claims/ClaimItem.tsx
+++ b/src/components/claims/ClaimItem.tsx
@@ -285,8 +285,10 @@ export default function ClaimItem({
               <button
                 className='cursor-pointer mt-5 text-white hover:bg-poidhRed bg-poidhRed bg-opacity-30 border border-poidhRed rounded-[8px] py-2 px-5'
                 onClick={() => {
+                  // mustUseVoteFlow, not hasParticipants: the contract keeps rejecting
+                  // acceptClaim after every outside contributor has withdrawn.
                   if (
-                    bounty.data.hasParticipants
+                    bounty.data.mustUseVoteFlow
                   ) {
                     setShowVotingConfirm(true);
                   } else {
@@ -294,7 +296,7 @@ export default function ClaimItem({
                   }
                 }}
               >
-                {bounty.data.hasParticipants
+                {bounty.data.mustUseVoteFlow
                   ? 'propose winner'
                   : 'accept'}
               </button>

--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -68,10 +68,7 @@ export const bountiesRouter = {
         extra: extraData,
         hasClaims: claims.length > 0,
         hasParticipants,
-        mustUseVoteFlow: await readMustUseVoteFlow(
-          bountyData,
-          hasParticipants
-        ),
+        mustUseVoteFlow: await readMustUseVoteFlow(bountyData, hasParticipants),
         amountSort,
       };
     }),

--- a/src/trpc/routers/bounties.ts
+++ b/src/trpc/routers/bounties.ts
@@ -3,6 +3,33 @@ import { baseProcedure } from '../init';
 import prisma from 'prisma/prisma';
 import { addressSchema } from '../serverTypes';
 import { checkIsIssuer } from './admin';
+import { everHadExternalContributor } from '@/utils/web3';
+import type { ChainId } from '@/utils/types';
+
+/**
+ * Which payout button the issuer should be offered.
+ *
+ * `hasParticipants` counts the participations that are still live, but the contract gates
+ * `acceptClaim` on the sticky `everHadExternalContributor` flag, so the two disagree for any
+ * open bounty whose outside contributors have all withdrawn. Branching the UI on the live
+ * count offers those issuers an "accept" that can only revert, with no route to the vote flow.
+ * The live count is the fallback when the chain read fails.
+ */
+async function readMustUseVoteFlow(
+  bounty: { onChainId: number; chainId: number; isMultiplayer: boolean },
+  hasParticipants: boolean
+): Promise<boolean> {
+  if (!bounty.isMultiplayer) {
+    return false;
+  }
+
+  const flag = await everHadExternalContributor({
+    chainId: bounty.chainId as ChainId,
+    onChainId: bounty.onChainId,
+  });
+
+  return flag ?? hasParticipants;
+}
 
 export const bountiesRouter = {
   fetch: baseProcedure
@@ -34,11 +61,17 @@ export const bountiesRouter = {
       const { claims, participations, extra, ...bountyData } = bounty;
       const { amountSort, ...extraData } = extra;
 
+      const hasParticipants = participations.length > 1;
+
       return {
         ...bountyData,
         extra: extraData,
         hasClaims: claims.length > 0,
-        hasParticipants: participations.length > 1,
+        hasParticipants,
+        mustUseVoteFlow: await readMustUseVoteFlow(
+          bountyData,
+          hasParticipants
+        ),
         amountSort,
       };
     }),

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -1,6 +1,40 @@
 import { ABI } from '@/constant';
-import { chains } from '@/utils/config';
-import { Netname } from '@/utils/types';
+import { chains, getChainById } from '@/utils/config';
+import { ChainId, Netname } from '@/utils/types';
+
+/**
+ * Reads the contract flag that decides whether a bounty can still be paid with a direct
+ * `acceptClaim`, or has to go through the vote flow. `true` means the vote flow.
+ *
+ * The gate on chain is the sticky `everHadExternalContributor` flag, not the number of
+ * contributors the bounty has right now: `withdrawFromOpenBounty` zeroes the contributor's
+ * slot and never clears the flag. So an open bounty whose only outside contributor has left
+ * looks solo from the indexed participation rows, but `acceptClaim` still reverts with
+ * `NotSoloBounty()` and the issuer has to go through `submitClaimForVote`.
+ *
+ * Returns `null` when the chain is unreachable, or runs a contract with no such flag
+ * (mainnet and degen are still on the older one), so callers can fall back.
+ */
+export async function everHadExternalContributor({
+  chainId,
+  onChainId,
+}: {
+  chainId: ChainId;
+  onChainId: number;
+}): Promise<boolean | null> {
+  try {
+    const chain = getChainById({ chainId });
+
+    return await chain.provider.readContract({
+      abi: ABI,
+      address: chain.contracts.mainContract as `0x${string}`,
+      functionName: 'everHadExternalContributor',
+      args: [BigInt(onChainId)],
+    });
+  } catch {
+    return null;
+  }
+}
 
 export async function bountyCurrentVotingClaim({
   chainName,

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -12,8 +12,9 @@ import { ChainId, Netname } from '@/utils/types';
  * looks solo from the indexed participation rows, but `acceptClaim` still reverts with
  * `NotSoloBounty()` and the issuer has to go through `submitClaimForVote`.
  *
- * Returns `null` when the chain is unreachable, or runs a contract with no such flag
- * (mainnet and degen are still on the older one), so callers can fall back.
+ * All four configured chains run this contract and expose the flag, so the only reason this
+ * returns `null` is that the read itself failed (RPC down, rate limited, wrong chain id).
+ * Callers fall back to the indexed count in that case.
  */
 export async function everHadExternalContributor({
   chainId,


### PR DESCRIPTION
## The bug

On a claim, the issuer's button is chosen by the live participation count:

```ts
// src/components/claims/ClaimItem.tsx
if (bounty.data.hasParticipants) { setShowVotingConfirm(true) } else { setShowAcceptConfirm(true) }
...
{bounty.data.hasParticipants ? 'propose winner' : 'accept'}
```

```ts
// src/trpc/routers/bounties.ts
hasParticipants: participations.length > 1,
```

The contract does not gate on the live count. It gates on a sticky flag:

```solidity
// acceptClaim
if (everHadExternalContributor[bountyId]) revert NotSoloBounty();
```

and `withdrawFromOpenBounty` zeroes the contributor's slot without ever clearing that flag:

```solidity
participantAmounts[bountyId][idx] = 0;
participants[bountyId][idx] = address(0);
// everHadExternalContributor is never reset
```

So once every outside contributor of an open bounty has withdrawn, `participations.length`
drops back to 1, the UI flips from **propose winner** back to **accept**, and the only button
the issuer is offered reverts with `NotSoloBounty()` — every time. `submitClaimForVote` appears
nowhere else in the app, so there is no other route to a payout from the UI.

Funds are not at risk: `cancelOpenBounty` still refunds, and an issuer who knows the ABI can
call `submitClaimForVote` directly. The cost is that a bounty with claims on it can no longer
be paid out through poidh.xyz.

## Reproducing it against production, without sending a transaction

Bounty **237 on Base** is in this state right now (2 claims, 77 days old):

```
$ curl -s https://poidh.xyz/base/bounty/1223/data | jq '{onChainId, isMultiplayer, hasParticipants, inProgress, isCanceled}'
{ "onChainId": 237, "isMultiplayer": true, "hasParticipants": false, "inProgress": true, "isCanceled": false }
```

```
# everHadExternalContributor(237) -> selector 0xb04f5ebd
$ curl -s -X POST https://base.publicnode.com -H 'content-type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0x5555Fa783936C260f77385b4E153B9725feF1719","data":"0xb04f5ebd00000000000000000000000000000000000000000000000000000000000000ed"},"latest"]}'
{"jsonrpc":"2.0","id":1,"result":"0x0000000000000000000000000000000000000000000000000000000000000001"}

# getParticipants(237) -> selector 0xc1e3bd3e; addresses are [issuer, 0x0], amounts [1e15, 0]
$ curl -s -X POST https://base.publicnode.com -H 'content-type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0x5555Fa783936C260f77385b4E153B9725feF1719","data":"0xc1e3bd3e00000000000000000000000000000000000000000000000000000000000000ed"},"latest"]}'
{"jsonrpc":"2.0","id":1,"result":"0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c45d767eca8bba02a2b5d682aac0c80102c5e47d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000038d7ea4c680000000000000000000000000000000000000000000000000000000000000000000"}
```

`hasParticipants: false` → the issuer sees **accept** → `acceptClaim(237, …)` reverts.

Arbitrum **107** is in the same state (no claims on it yet, so nobody is blocked there today).

## How wide it is

I read all 353 Base and 150 Arbitrum bounties from the contract and compared each open, unpaid
one against `/<net>/bounty/<id>/data`:

- `hasParticipants` equals `(non-zero entries in getParticipants > 1)` on **61 of 61** bounties I
  could fetch — the indexer is a plain live count, which is what makes it disagree with the flag.
- **2** bounties are in the bricked state now (Base 237, Arbitrum 107).
- **21** Base and **8** Arbitrum open, unpaid bounties currently have only the issuer
  participating. Any third party can move one into the bricked state for gas alone:
  `joinOpenBounty` at `MIN_CONTRIBUTION` (0.00001 ETH), then `withdrawFromOpenBounty` to take
  that same 0.00001 ETH back. The flag stays set forever afterwards.

## The fix in this PR

`bounties.fetch` now reads `everHadExternalContributor` for multiplayer bounties and returns it
as `mustUseVoteFlow`; `ClaimItem` branches on that instead of on `hasParticipants`. The read is
wrapped so that an RPC failure
falls back to today's behaviour rather than breaking the page. `hasParticipants` is untouched and
still returned, since it is the right answer for "is this a multiplayer bounty".

The three other `participations.length > 1` sites (`accounts.ts`, `bounties.ts` list queries, and
the two `data/route.ts` handlers) are display-only, so I left them alone — but they will report
the same thing, and shouldn't be used to gate a payout.

I could not run `pnpm typecheck` locally (no pnpm on the machine I built this on), so please let
CI have the last word on the types.
