### PR TITLE
fix(lint): unblock CI on the empty toggleTheme placeholder

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -17,7 +17,9 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType>({
   theme: 'light',
-  toggleTheme: () => {},
+  toggleTheme: () => {
+    // Only reachable outside a ThemeProvider; the provider supplies the real one.
+  },
 });
 
 export function ThemeProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
`pnpm run lint:strict` currently fails on `staging` with exactly one error:

```
src/context/ThemeContext.tsx
  20:22  error  Unexpected empty method 'toggleTheme'  @typescript-eslint/no-empty-function

✖ 49 problems (1 error, 48 warnings)
```

The warnings are all under the `--max-warnings=98` cap, so this single error is the whole failure.

It matters more than a lint nit, because of the step order in `.github/workflows/lint.yml`:

```yaml
- name: 🔬 Lint
  run: pnpm run lint:strict

- name: 🔎 Type check
  run: pnpm run typecheck
```

The job exits at the lint step, so **`pnpm run typecheck` never runs on any pull request**. Every PR against this repo is red for this one reason, and none of them are being type-checked by CI. Fixing it turns the check back into a signal.

`@typescript-eslint/no-empty-function` treats a body containing a comment as non-empty, so the fix documents why the placeholder is there rather than adding a disable comment or an `allow` entry to `.eslintrc.js`. I checked that against the versions this repo pins (eslint 8.57.1, @typescript-eslint 5.62.0): the commented form passes, `() => {}` errors.

Behaviour is unchanged — that default is only ever reached by a consumer rendered outside `ThemeProvider`.

One file, three lines, and `prettier -c` is clean on it.

(Separately: I have #1457 open, and its types are exactly what CI can't currently check — but this stands on its own and I'd rather it not be bundled into that one.)