### PR TITLE
SKILL.md: a caught revert is not proof the claim array ended

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -296,6 +296,22 @@ async function confirmEmpty(others, bountyId) {
 }
 ```
 
+**Count the providers you actually have before trusting this.** `confirmEmpty` can only do its
+job if `others` is non-empty, and a chain configured with a single RPC silently has nothing to
+pass it — the guard degrades to "trust the one endpoint" without saying so. That is not
+hypothetical: my scanner ran Degen on one endpoint, so every Degen empty was a single provider's
+unchallenged word. Worse, the audit I wrote to find this class of bug inherited the same blind
+spot — it marked a row confirmed as soon as *any* endpoint reverted with its canary passing,
+which on a one-endpoint chain is the same-endpoint canary wearing a different hat.
+
+A second path to the same host does not count: `rpc.degen.tips/http` is not a second opinion
+about `rpc.degen.tips`. Find genuinely separate infrastructure, verify it answers the positive
+control, and make the single-provider case **fail loudly** rather than pass quietly:
+
+```js
+if (others.length === 0) throw new Error("cannot confirm an empty list with one provider");
+```
+
 Use one provider to detect the boundary and a different one to confirm it. Asking the same
 endpoint a second question only ever proves it is still talking to you.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -268,6 +268,37 @@ async function confirmEnd(poidh, bountyId, i) {
 If `confirmEnd` throws, the endpoint stopped answering — retry the whole walk on another
 provider. Do not record a count. The same rule applies to `userClaims` and `userBounties`.
 
+**The canary is a liveness check, not a proof about the key you asked for.** It reads a
+*different* `(bountyId, index)` pair, so it catches an endpoint that has stopped answering
+everything, and misses one that reverts a single key while serving the rest. That gap is
+real: a later scan of all 741 bounties across the four chains, run with the `confirmEnd`
+guard above, still recorded `no claims` for **2 of its 31 empties** — Arbitrum 125 (claim
+557, created 2026-06-15) and Arbitrum 146 (claim 622). Re-probing every endpoint showed both
+bounties answer `bountyClaims(id, 0)` normally. Since the guard only returns an empty list
+after the canary passes, the canary passed while the answer was wrong.
+
+So for the `i === 0` case — the one that produces an *empty* list, the costliest wrong answer
+here — confirm on a **different provider** rather than on the same one:
+
+```js
+// `others` must exclude the provider that reported the empty -- that is the whole point.
+async function confirmEmpty(others, bountyId) {
+  for (const p of others) {
+    try {
+      await p.bountyClaims(bountyId, 0);
+      return false;                                 // it reads: the list is NOT empty
+    } catch {
+      try { await canary(p); } catch { continue; }  // unhealthy: its revert proves nothing
+      return true;                                  // healthy and still reverts: genuinely empty
+    }
+  }
+  throw new Error("no healthy second provider could confirm the empty list");
+}
+```
+
+Use one provider to detect the boundary and a different one to confirm it. Asking the same
+endpoint a second question only ever proves it is still talking to you.
+
 ### A returned row is not necessarily a record
 
 The same convenience getters allocate a fixed array of 10 and never shrink it, so short

--- a/SKILL.md
+++ b/SKILL.md
@@ -190,13 +190,21 @@ claims(uint256 claimId) returns (
 ```js
 const ids = [];
 for (let i = 0; ; i++) {
-  try { ids.push(await poidh.bountyClaims(bountyId, i)); }
-  catch { break; } // out of bounds: the array ended
+  let id;
+  try {
+    id = await poidh.bountyClaims(bountyId, i);
+  } catch {
+    await confirmEnd(poidh, bountyId, i); // throws unless the array really ended
+    break;
+  }
+  ids.push(id);
 }
 
 const claims = [];
 for (const id of ids) claims.push(await poidh.claims(id));
 ```
+
+`confirmEnd` is not optional — see the next section for why, and for its implementation.
 
 The same shape replaces all four broken getters:
 
@@ -206,6 +214,59 @@ The same shape replaces all four broken getters:
 | `getClaimsByBountyId(bountyId, offset)` | `bountyClaims(bountyId, i)` walked to revert, then `claims(id)` |
 | `getBountiesByUser(user, offset)` | `userBounties(user, i)` walked to revert, then `bounties(id)` |
 | `getClaimsByUser(user, offset)` | `userClaims(user, i)` walked to revert, then `claims(id)` |
+
+### `catch { break }` is not a termination condition
+
+The walk above is only exact if the error that ends it really was an out-of-bounds read.
+Through a JSON-RPC provider it usually cannot be told apart from a failure:
+
+* Via ethers, a genuine out-of-bounds read and a throttled endpoint are **byte-identical** —
+  `code: "CALL_EXCEPTION"`, `data: null`, `shortMessage: "missing revert data"`. Measured
+  2026-09-02 on Base against the deployed v3 contract, the same on all of `base.drpc.org`,
+  `mainnet.base.org` and `base-rpc.publicnode.com`. There is no `Panic(0x32)` payload to
+  recognise, so no property of the error object separates the two cases.
+* A raw `eth_call` does distinguish them — out of bounds returns
+  `{"error":{"code":3,"message":"execution reverted"}}`, while a rate limit returns
+  `-32016` / `-32005` or HTTP 429 — but ethers discards the code on the way out.
+* It is not only rate limits. On the same day `base.meowrpc.com` answered
+  `{"code":-32000,"message":"The method eth_call is not supported."}` for *every* call,
+  including `claims(1)`. Through ethers that is, again, `missing revert data` — so a
+  provider that cannot perform the read at all reports "this bounty has no claims".
+
+So `catch { break }` turns a rate limit into "the array ended", and the walk returns a
+**short list, most often the empty one**. Nothing throws and nothing looks wrong. An empty
+list reads as *nobody has claimed this bounty*, which is the same wrong answer this section
+exists to prevent, arrived at from the other side.
+
+This is not hypothetical. A scan of the first 205 Base bounties written exactly as above
+classified 16 of them as having no claims; re-probing all 16 across three endpoints showed
+**9 of the 16 had at least one claim**. The visible symptom was nil — the run exited 0 with a
+plausible-looking table.
+
+**Never accept the terminating error on its own.** Make the same endpoint, asked immediately
+afterwards, answer a read of the same function whose result is already known:
+
+```js
+// Claim ids are global and increase, so claim #1 is element 0 of its own bounty's array,
+// and the arrays are push-only -- acceptance never removes an entry. So this is a call of
+// exactly the shape under test whose correct answer is permanent.
+let canaryBounty;
+async function canary(poidh) {
+  canaryBounty ??= (await poidh.claims(1)).bountyId;
+  if ((await poidh.bountyClaims(canaryBounty, 0)) !== 1n) throw new Error("canary mismatch");
+}
+
+async function confirmEnd(poidh, bountyId, i) {
+  if (i > 0) {
+    await poidh.bountyClaims(bountyId, i - 1); // must still read; throws if the endpoint died
+    return;
+  }
+  await canary(poidh); // no i-1 to fall back on: prove the endpoint can still answer at all
+}
+```
+
+If `confirmEnd` throws, the endpoint stopped answering — retry the whole walk on another
+provider. Do not record a count. The same rule applies to `userClaims` and `userBounties`.
 
 ### A returned row is not necessarily a record
 


### PR DESCRIPTION
This corrects guidance I contributed myself in #1455.

### The bug

The `bountyClaims` walk in SKILL.md terminates on a bare catch:

```js
try { ids.push(await poidh.bountyClaims(bountyId, i)); }
catch { break; } // out of bounds: the array ended
```

That is only exact if the error really was an out-of-bounds read. Through ethers it usually cannot be told apart from a failure. Measured on Base 2026-09-02 against the deployed v3 contract, a genuine out-of-bounds read and a throttled endpoint are **byte-identical**:

```
code: "CALL_EXCEPTION", data: null, shortMessage: "missing revert data"
```

the same on `base.drpc.org`, `mainnet.base.org` and `base-rpc.publicnode.com`. There is no `Panic(0x32)` payload to recognise, so no property of the error object separates the two cases. A raw `eth_call` does distinguish them — out of bounds gives `{"error":{"code":3,"message":"execution reverted"}}`, a rate limit gives `-32016`/`-32005`/HTTP 429 — but ethers discards the code on the way out.

It is not only rate limits. On the same day `base.meowrpc.com` answered `{"code":-32000,"message":"The method eth_call is not supported."}` to every call, including `claims(1)`. Through ethers: `missing revert data` again. A provider that cannot perform the read at all reports "this bounty has no claims".

So the failure mode is a **short list, most often the empty one**, with nothing thrown and nothing visibly wrong. An empty list reads as *nobody has entered this bounty* — the same wrong answer the surrounding section already exists to prevent, reached from the other side.

### How much it matters

A scan of the first 205 Base bounties written exactly to the current snippet classified 16 of them as having no claims. Re-probing all 16 across three endpoints showed **9 of the 16 had at least one claim**. The run exited 0 with a plausible-looking table.

### The fix

Never accept the terminating error on its own — make the same endpoint, asked immediately afterwards, answer a read of the same function whose result is already known:

```js
let canaryBounty;
async function canary(poidh) {
  canaryBounty ??= (await poidh.claims(1)).bountyId;
  if ((await poidh.bountyClaims(canaryBounty, 0)) !== 1n) throw new Error("canary mismatch");
}

async function confirmEnd(poidh, bountyId, i) {
  if (i > 0) { await poidh.bountyClaims(bountyId, i - 1); return; }
  await canary(poidh);
}
```

For `i > 0` the control is index `i-1` of the same array. For `i === 0` there is no `i-1`, so the control is derived from the chain rather than configured: claim ids are global and increasing, so claim #1 is element 0 of its own bounty's array, and the arrays are push-only (acceptance never removes an entry), which makes `bountyClaims(claims(1).bountyId, 0) === 1n` permanently true. On Base that bounty id is 0.

If `confirmEnd` throws, the endpoint stopped answering — retry the walk on another provider, do not record a count.

### Verification

The exact snippets in this diff were run against the live Base contract:

```
canary bounty id = 0
  #166 -> [1402]
  #76  -> []                                    (genuinely empty)
  #344 -> [2339,2351,2402,2413,2423,2447,2479,2481,2484]
  #11  -> [95,110]
  unreachable endpoint -> threw, rather than returning []
```

Docs only — no code changes. Same rule applies to `userClaims` and `userBounties`, noted in the text.