### PR TITLE
Add green cyber theme

### DIFF
--- a/src/app/a/[album]/page.tsx
+++ b/src/app/a/[album]/page.tsx
@@ -82,6 +82,7 @@ export default function Album({ params }: { params: { album: string } }) {
               }}
             />
             <button
+              aria-pressed={display === 'open'}
               ref={(el) => {
                 tabRefs.current[0] = el;
               }}
@@ -100,6 +101,7 @@ export default function Album({ params }: { params: { album: string } }) {
               </span>
             </button>
             <button
+              aria-pressed={display === 'progress'}
               ref={(el) => {
                 tabRefs.current[1] = el;
               }}
@@ -118,6 +120,7 @@ export default function Album({ params }: { params: { album: string } }) {
               </span>
             </button>
             <button
+              aria-pressed={display === 'past'}
               ref={(el) => {
                 tabRefs.current[2] = el;
               }}

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -119,6 +119,7 @@ export default function Explore() {
                 }}
               />
               <button
+                aria-pressed={display === 'albums'}
                 ref={(el) => {
                   tabRefs.current[0] = el;
                 }}
@@ -128,6 +129,7 @@ export default function Explore() {
                 albums
               </button>
               <button
+                aria-pressed={display === 'bounties'}
                 ref={(el) => {
                   tabRefs.current[1] = el;
                 }}
@@ -137,6 +139,7 @@ export default function Explore() {
                 bounties
               </button>
               <button
+                aria-pressed={display === 'users'}
                 ref={(el) => {
                   tabRefs.current[2] = el;
                 }}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -101,7 +101,7 @@ export default function RootLayout({
         <link rel='canonical' href={url} />
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||(t===null&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark');}}catch(e){}})();`,
+            __html: `(function(){try{var t=localStorage.getItem('theme');var valid=t==='light'||t==='dark'||t==='cyber';var dark=t==='dark'||t==='cyber'||(!valid&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.classList.toggle('dark',dark);document.documentElement.classList.toggle('cyber',t==='cyber');}catch(e){}})();`,
           }}
         />
       </head>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -129,6 +129,7 @@ export default function Home() {
                 }}
               />
               <button
+                aria-pressed={display === 'open'}
                 ref={(el) => {
                   tabRefs.current[0] = el;
                 }}
@@ -141,6 +142,7 @@ export default function Home() {
                 new bounties
               </button>
               <button
+                aria-pressed={display === 'progress'}
                 ref={(el) => {
                   tabRefs.current[1] = el;
                 }}
@@ -153,6 +155,7 @@ export default function Home() {
                 voting in progress
               </button>
               <button
+                aria-pressed={display === 'past'}
                 ref={(el) => {
                   tabRefs.current[2] = el;
                 }}

--- a/src/components/account/AccountInfo.tsx
+++ b/src/components/account/AccountInfo.tsx
@@ -267,6 +267,7 @@ export default function AccountInfo({ address }: { address: string }) {
                 }}
               />
               <button
+                aria-pressed={currentSection === 'nfts'}
                 ref={(el) => {
                   tabRefs.current[0] = el;
                 }}
@@ -276,6 +277,7 @@ export default function AccountInfo({ address }: { address: string }) {
                 NFTs({accountActivitiesCount.data?.nfts ?? 0})
               </button>
               <button
+                aria-pressed={currentSection === 'bounties'}
                 ref={(el) => {
                   tabRefs.current[1] = el;
                 }}
@@ -285,6 +287,7 @@ export default function AccountInfo({ address }: { address: string }) {
                 bounties ({accountActivitiesCount.data?.bounties ?? 0})
               </button>
               <button
+                aria-pressed={currentSection === 'claims'}
                 ref={(el) => {
                   tabRefs.current[2] = el;
                 }}

--- a/src/components/bounty/FormBounty.tsx
+++ b/src/components/bounty/FormBounty.tsx
@@ -242,8 +242,8 @@ export default function FormBounty({
       // Final safety check: make sure the poidh contract actually exists on the
       // network the connected wallet reports. This prevents ETH from being sent
       // to the same address on a chain where no poidh contract is deployed.
-      const contractAddress =
-        currentChain.contracts.mainContract as `0x${string}`;
+      const contractAddress = currentChain.contracts
+        .mainContract as `0x${string}`;
 
       const contractCode = await walletProvider.request({
         method: 'eth_getCode',
@@ -470,8 +470,7 @@ export default function FormBounty({
             ? {
                 '& .MuiDialog-paper': {
                   transform: open ? 'translateY(0)' : 'translateY(100%)',
-                  transition:
-                    'transform 0.3s cubic-bezier(0.4, 0.0, 0.2, 1)',
+                  transition: 'transform 0.3s cubic-bezier(0.4, 0.0, 0.2, 1)',
                 },
               }
             : {}
@@ -491,7 +490,6 @@ export default function FormBounty({
           {isMobile ? (
             <div className='flex items-center justify-between w-full sticky shrink-0'>
               <div style={{ width: '40px' }} />{' '}
-
               <button
                 onClick={onClose}
                 style={{
@@ -577,9 +575,7 @@ export default function FormBounty({
               />
 
               <div className='flex items-center justify-between gap-2 mb-1'>
-                <span className={isMobile ? 'text-base' : ''}>
-                  description
-                </span>
+                <span className={isMobile ? 'text-base' : ''}>description</span>
 
                 <div className='flex items-center gap-2 shrink-0'>
                   <button
@@ -622,11 +618,7 @@ export default function FormBounty({
                 <div
                   className={`border rounded-md px-3 py-3 border-[#D1ECFF] overflow-y-auto ${
                     isMobile ? 'mb-5' : 'mb-4'
-                  } ${
-                    isMobile
-                      ? 'min-h-[150px]'
-                      : 'flex-1 min-h-[300px]'
-                  }`}
+                  } ${isMobile ? 'min-h-[150px]' : 'flex-1 min-h-[300px]'}`}
                   style={{
                     height:
                       isMobile && descriptionHeight
@@ -648,8 +640,8 @@ export default function FormBounty({
                     isMobile
                       ? 'relative mb-5'
                       : 'relative mb-4 flex-1 min-h-[300px]'
-                    }
-                  >
+                  }
+                >
                   <textarea
                     ref={textareaRef}
                     value={description}
@@ -730,9 +722,7 @@ export default function FormBounty({
               )}
 
               <div>
-                <span
-                  className={isMobile ? 'text-base mb-2' : 'font-semibold'}
-                >
+                <span className={isMobile ? 'text-base mb-2' : 'font-semibold'}>
                   reward
                 </span>
 
@@ -754,9 +744,7 @@ export default function FormBounty({
                       setAmount(raw);
 
                       if (!isNaN(value) && value > 0) {
-                        setUsdPerToken(
-                          parseFloat((value * price).toFixed(2))
-                        );
+                        setUsdPerToken(parseFloat((value * price).toFixed(2)));
                       } else {
                         setUsdPerToken(null);
                       }
@@ -880,17 +868,11 @@ export default function FormBounty({
               </div>
 
               <div>
-                <span
-                  className={isMobile ? 'text-base mb-2' : 'font-semibold'}
-                >
+                <span className={isMobile ? 'text-base mb-2' : 'font-semibold'}>
                   album
                 </span>
 
-                <div
-                  className={`relative mt-2 ${
-                    isMobile ? 'mb-5' : 'mb-6'
-                  }`}
-                >
+                <div className={`relative mt-2 ${isMobile ? 'mb-5' : 'mb-6'}`}>
                   <input
                     type='text'
                     value={album}
@@ -956,7 +938,9 @@ export default function FormBounty({
                       }}
                       sx={{
                         '& .MuiSwitch-thumb': {
-                          color: isOpenBounty ? '#F15E5F' : 'default',
+                          color: isOpenBounty
+                            ? 'var(--cyber-accent, #F15E5F)'
+                            : 'default',
                         },
 
                         '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track':
@@ -1001,7 +985,9 @@ export default function FormBounty({
                         }}
                         sx={{
                           '& .MuiSwitch-thumb': {
-                            color: isOpenBounty ? '#F15E5F' : 'default',
+                            color: isOpenBounty
+                              ? 'var(--cyber-accent, #F15E5F)'
+                              : 'default',
                           },
 
                           '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track':

--- a/src/components/global/DarkModeToggle.tsx
+++ b/src/components/global/DarkModeToggle.tsx
@@ -45,17 +45,27 @@ function MoonIcon({ size = 24 }: { size?: number }) {
 export default function DarkModeToggle() {
   const { theme, toggleTheme } = useTheme();
 
+  const nextTheme =
+    theme === 'light' ? 'night' : theme === 'dark' ? 'cyber' : 'day';
+  const label = `switch to ${nextTheme} mode`;
+
   return (
     <button
+      type='button'
+      title={label}
       onClick={toggleTheme}
       className='rounded-lg backdrop-blur-sm bg-white/30 h-10 w-10 flex items-center justify-center mr-2 hover:bg-white/20 transition-colors'
-      aria-label={
-        theme === 'dark'
-          ? 'switch to light mode'
-          : 'switch to dark mode'
-      }
+      aria-label={label}
     >
-      {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+      {theme === 'light' ? (
+        <MoonIcon />
+      ) : theme === 'dark' ? (
+        <span aria-hidden='true' className='font-mono text-lg'>
+          &gt;_
+        </span>
+      ) : (
+        <SunIcon />
+      )}
     </button>
   );
 }

--- a/src/components/global/GameButton.tsx
+++ b/src/components/global/GameButton.tsx
@@ -1,8 +1,15 @@
+'use client';
+
+import { useTheme } from '@/context/ThemeContext';
+
 export default function GameButton({
   hideShadow: hideGradient = false,
 }: {
   hideShadow?: boolean;
 }) {
+  const { theme } = useTheme();
+  const isCyber = theme === 'cyber';
+
   return (
     <div className='flex justify-center items-center'>
       <svg
@@ -20,7 +27,7 @@ export default function GameButton({
                 cx='79'
                 cy='79.5'
                 r='58'
-                fill='#E2EFFB'
+                fill='var(--cyber-accent-soft, #E2EFFB)'
                 filter='url(#bgShadow)'
               />
               <rect
@@ -29,7 +36,7 @@ export default function GameButton({
                 width='125'
                 height='125'
                 rx='62.5'
-                fill='#E2EFFB'
+                fill='var(--cyber-accent-soft, #E2EFFB)'
                 fillOpacity='0.5'
               />
               <rect
@@ -38,7 +45,7 @@ export default function GameButton({
                 width='124.062'
                 height='124.062'
                 rx='62.0312'
-                stroke='#D1ECFF'
+                stroke='var(--cyber-accent, #D1ECFF)'
                 strokeWidth='0.9375'
               />
             </>
@@ -100,7 +107,11 @@ export default function GameButton({
             <feGaussianBlur stdDeviation='4.375' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.362061 0 0 0 0 0.598517 0 0 0 0 0.825879 0 0 0 0.5 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.258824 0 0 0 0 0.843137 0 0 0 0 0.482353 0 0 0 0.5 0'
+                  : '0 0 0 0 0.362061 0 0 0 0 0.598517 0 0 0 0 0.825879 0 0 0 0.5 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -116,7 +127,11 @@ export default function GameButton({
             <feGaussianBlur stdDeviation='5' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.818424 0 0 0 0 0.9251 0 0 0 0 1 0 0 0 0.5 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.5 0'
+                  : '0 0 0 0 0.818424 0 0 0 0 0.9251 0 0 0 0 1 0 0 0 0.5 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -162,7 +177,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.608057 0 0 0 0 0.154864 0 0 0 0 0.157715 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.608057 0 0 0 0 0.154864 0 0 0 0 0.157715 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -179,7 +198,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.972549 0 0 0 0 0.592157 0 0 0 0 0.596078 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.972549 0 0 0 0 0.592157 0 0 0 0 0.596078 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -202,7 +225,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.847059 0 0 0 0 0.223529 0 0 0 0 0.227451 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.847059 0 0 0 0 0.223529 0 0 0 0 0.227451 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -270,7 +297,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.37 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.37 0'
+                  : '0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.37 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -287,7 +318,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.2 0'
+                  : '0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -321,7 +356,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.17 0'
+                  : '0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -337,8 +376,8 @@ export default function GameButton({
             y2='134'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint1_linear_615_3757'
@@ -348,8 +387,8 @@ export default function GameButton({
             y2='134'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='white' />
-            <stop offset='1' stopColor='#F15E5F' />
+            <stop stopColor='var(--cyber-accent-soft, white)' />
+            <stop offset='1' stopColor='var(--cyber-accent, #F15E5F)' />
           </linearGradient>
           <linearGradient
             id='paint2_linear_615_3757'
@@ -359,8 +398,8 @@ export default function GameButton({
             y2='125.581'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint3_linear_615_3757'
@@ -370,9 +409,9 @@ export default function GameButton({
             y2='118.551'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#D8393A' />
-            <stop offset='0.226722' stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#F89798' />
+            <stop stopColor='var(--cyber-accent-deep, #D8393A)' />
+            <stop offset='0.226722' stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-soft, #F89798)' />
           </linearGradient>
         </defs>
       </svg>
@@ -390,7 +429,7 @@ export default function GameButton({
             cx='79'
             cy='79.5'
             r='58'
-            fill='#E2EFFB'
+            fill='var(--cyber-accent-soft, #E2EFFB)'
             filter='url(#bgShadow)'
           />
           <rect
@@ -399,7 +438,7 @@ export default function GameButton({
             width='125'
             height='125'
             rx='62.5'
-            fill='#E2EFFB'
+            fill='var(--cyber-accent-soft, #E2EFFB)'
             fillOpacity='0.5'
           />
           <rect
@@ -408,7 +447,7 @@ export default function GameButton({
             width='124.062'
             height='124.062'
             rx='62.0312'
-            stroke='#D1ECFF'
+            stroke='var(--cyber-accent, #D1ECFF)'
             strokeWidth='0.9375'
           />
           <g filter='url(#filter1_iii_513_1935)'>
@@ -521,7 +560,11 @@ export default function GameButton({
             <feGaussianBlur stdDeviation='4.375' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.362061 0 0 0 0 0.598517 0 0 0 0 0.825879 0 0 0 0.5 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.258824 0 0 0 0 0.843137 0 0 0 0 0.482353 0 0 0 0.5 0'
+                  : '0 0 0 0 0.362061 0 0 0 0 0.598517 0 0 0 0 0.825879 0 0 0 0.5 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -537,7 +580,11 @@ export default function GameButton({
             <feGaussianBlur stdDeviation='5' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.818424 0 0 0 0 0.9251 0 0 0 0 1 0 0 0 0.5 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.5 0'
+                  : '0 0 0 0 0.818424 0 0 0 0 0.9251 0 0 0 0 1 0 0 0 0.5 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -583,7 +630,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.608057 0 0 0 0 0.154864 0 0 0 0 0.157715 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.608057 0 0 0 0 0.154864 0 0 0 0 0.157715 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -600,7 +651,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.972549 0 0 0 0 0.592157 0 0 0 0 0.596078 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.972549 0 0 0 0 0.592157 0 0 0 0 0.596078 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -623,7 +678,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.847059 0 0 0 0 0.223529 0 0 0 0 0.227451 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.847059 0 0 0 0 0.223529 0 0 0 0 0.227451 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -691,7 +750,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.37 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.37 0'
+                  : '0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.37 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -708,7 +771,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.2 0'
+                  : '0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -742,7 +809,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.17 0'
+                  : '0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -776,7 +847,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.2 0'
+                  : '0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -816,7 +891,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.608057 0 0 0 0 0.154864 0 0 0 0 0.157715 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.608057 0 0 0 0 0.154864 0 0 0 0 0.157715 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -833,7 +912,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.972549 0 0 0 0 0.592157 0 0 0 0 0.596078 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.972549 0 0 0 0 0.592157 0 0 0 0 0.596078 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -856,7 +939,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.847059 0 0 0 0 0.223529 0 0 0 0 0.227451 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.847059 0 0 0 0 0.223529 0 0 0 0 0.227451 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -890,7 +977,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.17 0'
+                  : '0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -964,7 +1055,11 @@ export default function GameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.17 0'
+                  : '0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -980,8 +1075,8 @@ export default function GameButton({
             y2='134'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint1_linear_513_1935'
@@ -991,8 +1086,8 @@ export default function GameButton({
             y2='134'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='white' />
-            <stop offset='1' stopColor='#F15E5F' />
+            <stop stopColor='var(--cyber-accent-soft, white)' />
+            <stop offset='1' stopColor='var(--cyber-accent, #F15E5F)' />
           </linearGradient>
           <linearGradient
             id='paint2_linear_513_1935'
@@ -1002,8 +1097,8 @@ export default function GameButton({
             y2='125.581'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint3_linear_513_1935'
@@ -1013,9 +1108,9 @@ export default function GameButton({
             y2='118.551'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#D8393A' />
-            <stop offset='0.226722' stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#F89798' />
+            <stop stopColor='var(--cyber-accent-deep, #D8393A)' />
+            <stop offset='0.226722' stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-soft, #F89798)' />
           </linearGradient>
           <linearGradient
             id='paint4_linear_513_1935'
@@ -1025,8 +1120,8 @@ export default function GameButton({
             y2='91.9808'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='white' />
-            <stop offset='1' stopColor='#FF9495' />
+            <stop stopColor='var(--cyber-accent-soft, white)' />
+            <stop offset='1' stopColor='var(--cyber-accent-soft, #FF9495)' />
           </linearGradient>
           <linearGradient
             id='paint5_linear_513_1935'
@@ -1036,8 +1131,8 @@ export default function GameButton({
             y2='134'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint6_linear_513_1935'
@@ -1047,8 +1142,8 @@ export default function GameButton({
             y2='134'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='white' />
-            <stop offset='1' stopColor='#F15E5F' />
+            <stop stopColor='var(--cyber-accent-soft, white)' />
+            <stop offset='1' stopColor='var(--cyber-accent, #F15E5F)' />
           </linearGradient>
           <linearGradient
             id='paint7_linear_513_1935'
@@ -1058,9 +1153,9 @@ export default function GameButton({
             y2='118.551'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#D8393A' />
-            <stop offset='0.226722' stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#F89798' />
+            <stop stopColor='var(--cyber-accent-deep, #D8393A)' />
+            <stop offset='0.226722' stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-soft, #F89798)' />
           </linearGradient>
           <linearGradient
             id='paint8_linear_513_1935'
@@ -1070,8 +1165,8 @@ export default function GameButton({
             y2='125.581'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint9_linear_513_1935'
@@ -1081,9 +1176,9 @@ export default function GameButton({
             y2='125.581'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#D8393A' />
-            <stop offset='0.9999' stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#F89798' />
+            <stop stopColor='var(--cyber-accent-deep, #D8393A)' />
+            <stop offset='0.9999' stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-soft, #F89798)' />
           </linearGradient>
           <linearGradient
             id='paint10_linear_513_1935'
@@ -1093,9 +1188,9 @@ export default function GameButton({
             y2='118.552'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#CC2E2F' />
-            <stop offset='0.9999' stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#F89798' />
+            <stop stopColor='var(--cyber-accent-deep, #CC2E2F)' />
+            <stop offset='0.9999' stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-soft, #F89798)' />
           </linearGradient>
         </defs>
       </svg>
@@ -1108,6 +1203,9 @@ export function PlainGameButton({
 }: {
   hideShadow?: boolean;
 }) {
+  const { theme } = useTheme();
+  const isCyber = theme === 'cyber';
+
   return (
     <div className='flex justify-center items-center'>
       <svg
@@ -1125,7 +1223,7 @@ export function PlainGameButton({
                 cx='79'
                 cy='79.5'
                 r='58'
-                fill='#E2EFFB'
+                fill='var(--cyber-accent-soft, #E2EFFB)'
                 filter='url(#bgShadow)'
               />
               <rect
@@ -1134,7 +1232,7 @@ export function PlainGameButton({
                 width='125'
                 height='125'
                 rx='62.5'
-                fill='#E2EFFB'
+                fill='var(--cyber-accent-soft, #E2EFFB)'
                 fillOpacity='0.5'
               />
               <rect
@@ -1143,7 +1241,7 @@ export function PlainGameButton({
                 width='124.062'
                 height='124.062'
                 rx='62.0312'
-                stroke='#D1ECFF'
+                stroke='var(--cyber-accent, #D1ECFF)'
                 strokeWidth='0.9375'
               />
             </>
@@ -1205,7 +1303,11 @@ export function PlainGameButton({
             <feGaussianBlur stdDeviation='4.375' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.362061 0 0 0 0 0.598517 0 0 0 0 0.825879 0 0 0 0.5 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.258824 0 0 0 0 0.843137 0 0 0 0 0.482353 0 0 0 0.5 0'
+                  : '0 0 0 0 0.362061 0 0 0 0 0.598517 0 0 0 0 0.825879 0 0 0 0.5 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -1221,7 +1323,11 @@ export function PlainGameButton({
             <feGaussianBlur stdDeviation='5' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.818424 0 0 0 0 0.9251 0 0 0 0 1 0 0 0 0.5 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.5 0'
+                  : '0 0 0 0 0.818424 0 0 0 0 0.9251 0 0 0 0 1 0 0 0 0.5 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -1267,7 +1373,11 @@ export function PlainGameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.608057 0 0 0 0 0.154864 0 0 0 0 0.157715 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.608057 0 0 0 0 0.154864 0 0 0 0 0.157715 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -1284,7 +1394,11 @@ export function PlainGameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.972549 0 0 0 0 0.592157 0 0 0 0 0.596078 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.972549 0 0 0 0 0.592157 0 0 0 0 0.596078 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -1307,7 +1421,11 @@ export function PlainGameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.847059 0 0 0 0 0.223529 0 0 0 0 0.227451 0 0 0 1 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.12549 0 0 0 0 0.588235 0 0 0 0 0.301961 0 0 0 1 0'
+                  : '0 0 0 0 0.847059 0 0 0 0 0.223529 0 0 0 0 0.227451 0 0 0 1 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -1375,7 +1493,11 @@ export function PlainGameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.37 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.37 0'
+                  : '0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.37 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -1392,7 +1514,11 @@ export function PlainGameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.2 0'
+                  : '0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -1426,7 +1552,11 @@ export function PlainGameButton({
             <feComposite in2='hardAlpha' operator='arithmetic' k2='-1' k3='1' />
             <feColorMatrix
               type='matrix'
-              values='0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              values={
+                isCyber
+                  ? '0 0 0 0 0.631373 0 0 0 0 0.956863 0 0 0 0 0.737255 0 0 0 0.17 0'
+                  : '0 0 0 0 0.929167 0 0 0 0 0.937667 0 0 0 0 1 0 0 0 0.17 0'
+              }
             />
             <feBlend
               mode='normal'
@@ -1442,8 +1572,8 @@ export function PlainGameButton({
             y2='134'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint1_linear_615_3757'
@@ -1453,8 +1583,8 @@ export function PlainGameButton({
             y2='134'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='white' />
-            <stop offset='1' stopColor='#F15E5F' />
+            <stop stopColor='var(--cyber-accent-soft, white)' />
+            <stop offset='1' stopColor='var(--cyber-accent, #F15E5F)' />
           </linearGradient>
           <linearGradient
             id='paint2_linear_615_3757'
@@ -1464,8 +1594,8 @@ export function PlainGameButton({
             y2='125.581'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint3_linear_615_3757'
@@ -1475,9 +1605,9 @@ export function PlainGameButton({
             y2='118.551'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#D8393A' />
-            <stop offset='0.226722' stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#F89798' />
+            <stop stopColor='var(--cyber-accent-deep, #D8393A)' />
+            <stop offset='0.226722' stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-soft, #F89798)' />
           </linearGradient>
         </defs>
       </svg>

--- a/src/components/global/Logo.tsx
+++ b/src/components/global/Logo.tsx
@@ -298,8 +298,8 @@ export default function Logo() {
             y2='37.5024'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint1_linear_1_10419'
@@ -309,8 +309,8 @@ export default function Logo() {
             y2='37.5024'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint2_linear_1_10419'
@@ -320,8 +320,8 @@ export default function Logo() {
             y2='37.5024'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint3_linear_1_10419'
@@ -331,8 +331,8 @@ export default function Logo() {
             y2='37.5024'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint4_linear_1_10419'
@@ -342,8 +342,8 @@ export default function Logo() {
             y2='37.5024'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint5_linear_1_10419'
@@ -353,8 +353,8 @@ export default function Logo() {
             y2='11.4778'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint6_linear_1_10419'
@@ -364,8 +364,8 @@ export default function Logo() {
             y2='7.25733'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint7_linear_1_10419'
@@ -376,7 +376,7 @@ export default function Logo() {
             gradientUnits='userSpaceOnUse'
           >
             <stop stopColor='white' />
-            <stop offset='1' stopColor='#F15E5F' />
+            <stop offset='1' stopColor='var(--cyber-accent, #F15E5F)' />
           </linearGradient>
           <linearGradient
             id='paint8_linear_1_10419'
@@ -386,8 +386,8 @@ export default function Logo() {
             y2='6.13621'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#D8393A' />
+            <stop stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-deep, #D8393A)' />
           </linearGradient>
           <linearGradient
             id='paint9_linear_1_10419'
@@ -397,9 +397,9 @@ export default function Logo() {
             y2='5.20018'
             gradientUnits='userSpaceOnUse'
           >
-            <stop stopColor='#D8393A' />
-            <stop offset='0.226722' stopColor='#F15E5F' />
-            <stop offset='1' stopColor='#F89798' />
+            <stop stopColor='var(--cyber-accent-deep, #D8393A)' />
+            <stop offset='0.226722' stopColor='var(--cyber-accent, #F15E5F)' />
+            <stop offset='1' stopColor='var(--cyber-accent-soft, #F89798)' />
           </linearGradient>
         </defs>
       </svg>

--- a/src/components/global/Navbar.tsx
+++ b/src/components/global/Navbar.tsx
@@ -65,7 +65,7 @@ export default function Navbar({
   if (isMobile) {
     return (
       <>
-        <nav className='fixed bottom-0 left-0 right-0 h-20 z-40 how-it-works-hidden shadow-[0_4px_24px_0_rgba(80,160,220,0.14)] android:pb-10 pb-4'>
+        <nav className='fixed bottom-0 left-0 right-0 h-20 z-40 how-it-works-hidden shadow-[0_4px_24px_0_var(--cyber-nav-shadow,rgba(80,160,220,0.14))] android:pb-10 pb-4'>
           <div className='absolute inset-0 rounded-t-3xl bg-gradient-to-b from-[#7db3e0] to-[#b3d8f7] dark:from-[#0d1b2e] dark:to-[#132b47] backdrop-blur-sm' />
 
           <div className='relative h-full flex items-center justify-between pt-2'>

--- a/src/components/global/WalletProvider.tsx
+++ b/src/components/global/WalletProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { RainbowKitProvider } from '@rainbow-me/rainbowkit';
+import { darkTheme, RainbowKitProvider } from '@rainbow-me/rainbowkit';
+import { useTheme } from '@/context/ThemeContext';
 import { config } from '@/wagmiConfig';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { WagmiProvider } from 'wagmi';
@@ -8,10 +9,23 @@ import { WagmiProvider } from 'wagmi';
 const queryClient = new QueryClient();
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const { theme } = useTheme();
+
   return (
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider>{children}</RainbowKitProvider>
+        <RainbowKitProvider
+          theme={
+            theme === 'cyber'
+              ? darkTheme({
+                  accentColor: '#42d77b',
+                  accentColorForeground: '#03180f',
+                })
+              : undefined
+          }
+        >
+          {children}
+        </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>
   );

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -8,7 +8,12 @@ import {
   type ReactNode,
 } from 'react';
 
-type Theme = 'light' | 'dark';
+type Theme = 'light' | 'dark' | 'cyber';
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle('dark', theme !== 'light');
+  document.documentElement.classList.toggle('cyber', theme === 'cyber');
+}
 
 interface ThemeContextType {
   theme: Theme;
@@ -17,29 +22,42 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType>({
   theme: 'light',
-  toggleTheme: () => {},
+  toggleTheme: () => undefined,
 });
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>('light');
 
   useEffect(() => {
-    const stored = localStorage.getItem('theme') as Theme | null;
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem('theme');
+    } catch {
+      // The toggle still works when browser storage is unavailable.
+    }
     const prefersDark = window.matchMedia(
       '(prefers-color-scheme: dark)'
     ).matches;
-    const initial = stored ?? (prefersDark ? 'dark' : 'light');
+    const initial: Theme =
+      stored === 'light' || stored === 'dark' || stored === 'cyber'
+        ? stored
+        : prefersDark
+        ? 'dark'
+        : 'light';
     setTheme(initial);
-    document.documentElement.classList.toggle('dark', initial === 'dark');
+    applyTheme(initial);
   }, []);
 
   const toggleTheme = () => {
-    setTheme((prev) => {
-      const next = prev === 'light' ? 'dark' : 'light';
+    const next: Theme =
+      theme === 'light' ? 'dark' : theme === 'dark' ? 'cyber' : 'light';
+    applyTheme(next);
+    setTheme(next);
+    try {
       localStorage.setItem('theme', next);
-      document.documentElement.classList.toggle('dark', next === 'dark');
-      return next;
-    });
+    } catch {
+      // Keep the selected theme for this session when storage is unavailable.
+    }
   };
 
   return (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -320,8 +320,7 @@ textarea.resize-y::-webkit-scrollbar-thumb {
   justify-content: center;
   align-items: flex-start;
 
-  animation:
-    konami-camera-enter 0.45s steps(6, end) forwards,
+  animation: konami-camera-enter 0.45s steps(6, end) forwards,
     konami-camera-shake 0.15s steps(2, end) 1.05s,
     konami-camera-exit 0.45s steps(6, end) 2.25s forwards;
 }
@@ -375,9 +374,7 @@ textarea.resize-y::-webkit-scrollbar-thumb {
   background: #303030;
   border: 6px solid #000;
 
-  box-shadow:
-    6px 6px 0 #000,
-    inset 0 -12px 0 rgba(0, 0, 0, 0.18);
+  box-shadow: 6px 6px 0 #000, inset 0 -12px 0 rgba(0, 0, 0, 0.18);
 }
 
 .konami-camera-viewfinder {
@@ -635,4 +632,154 @@ textarea.resize-y::-webkit-scrollbar-thumb {
   .konami-photo {
     animation-duration: 0.01ms;
   }
+}
+
+/* Cyber is a dark theme variant; all overrides are scoped to this selection. */
+html.cyber {
+  color-scheme: dark;
+  --poidh-red: 66 215 123;
+  --poidh-blue: 9 41 28;
+  --cyber-accent: #42d77b;
+  --cyber-nav-shadow: rgb(66 215 123 / 0.14);
+  --cyber-accent-deep: #20964d;
+  --cyber-accent-soft: #a1f4bc;
+}
+
+html.cyber body {
+  color: #dbebdc;
+  background: #03180f;
+}
+
+html.cyber .bg-whiteblue,
+html.cyber [class~='dark:bg-[#132b47]'],
+html.cyber [class~='dark:bg-[#0d1b2e]'],
+html.cyber [class~='dark:bg-[#0d1b2e]/50'] {
+  background-color: #09291c;
+}
+
+/* Existing dialog classes use !important to override Material UI. */
+html.cyber [class~='dark:!bg-[#132b47]'] {
+  background-color: #09291c !important;
+}
+
+html.cyber [class~='dark:bg-[#2a4a6b]'] {
+  background-color: #123b29;
+}
+
+html.cyber [class~='dark:from-[#0d1b2e]'] {
+  --tw-gradient-from: #03180f var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(3 24 15 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+html.cyber [class~='dark:via-[#1a3a5c]'] {
+  --tw-gradient-stops: var(--tw-gradient-from),
+    #123b29 var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+html.cyber [class~='dark:to-[#0d1b2e]'],
+html.cyber [class~='dark:to-[#132b47]'],
+html.cyber [class~='dark:to-[#15304f]'],
+html.cyber [class~='dark:to-[#1a3a5c]'] {
+  --tw-gradient-to: #09291c var(--tw-gradient-to-position);
+}
+
+html.cyber .border-white,
+html.cyber [class~='border-[#D1ECFF]'],
+html.cyber [class~='dark:border-[#4a7ab5]'] {
+  border-color: #315342;
+}
+
+html.cyber .text-white {
+  color: #dbebdc;
+}
+
+html.cyber .bg-blur,
+html.cyber .bg-blur-white,
+html.cyber [class~='bg-white/30'],
+html.cyber [class~='bg-white/20'],
+html.cyber [class~='bg-[#D1ECFF]/20'] {
+  background-color: rgb(66 215 123 / 0.12);
+}
+
+html.cyber [class~='hover:bg-white/20']:hover,
+html.cyber [class~='hover:bg-[#D1ECFF]/20']:hover {
+  background-color: rgb(66 215 123 / 0.2);
+}
+
+html.cyber .bountyItem.pendingClaims .bg-gradient {
+  background: linear-gradient(to right, #20964d, #42d77b);
+}
+
+html.cyber .bountyItem .borderBox {
+  border: 1px solid #315342 !important;
+}
+
+html.cyber .bountyItem:hover .borderBox {
+  background-color: #123b29;
+  border-color: #42d77b !important;
+  box-shadow: 0 0 12px rgb(66 215 123 / 0.12);
+}
+
+html.cyber .bountyItem p {
+  color: #91aa99;
+}
+
+html.cyber :is(button, a, input, textarea, select):focus-visible {
+  outline: 2px solid #42d77b;
+  outline-offset: 3px;
+}
+
+/* These surfaces can be rendered in portals outside the page container. */
+html.cyber .MuiDialog-paper,
+html.cyber .MuiDrawer-paper,
+html.cyber .MuiMenu-paper {
+  background: #09291c !important;
+  color: #dbebdc !important;
+  border-color: #315342 !important;
+}
+
+html.cyber .MuiSwitch-colorPrimary.Mui-checked {
+  color: #42d77b;
+}
+
+html.cyber .Toastify__toast-theme--light {
+  background-color: #09291c !important;
+  border-color: #315342 !important;
+  color: #dbebdc !important;
+}
+
+html.cyber * {
+  scrollbar-color: #315342 transparent;
+}
+
+html.cyber ::-webkit-scrollbar-thumb {
+  background-color: #315342;
+}
+
+/* Selected controls sit on the bright accent, so use dark foregrounds. */
+html.cyber #btn-container button[aria-pressed='true'],
+html.cyber .bg-poidhRed.text-white {
+  color: #03180f;
+}
+
+html.cyber [class~='bg-[#cf5d5d]'] {
+  background-color: #20964d;
+}
+html.cyber [class~='bg-[#102A43]'] {
+  background-color: #09291c;
+}
+html.cyber [class~='border-t-[#ff6e6e]'],
+html.cyber [class~='border-l-[#ff6e6e]'] {
+  border-top-color: #a1f4bc;
+  border-left-color: #a1f4bc;
+}
+html.cyber [class~='border-r-[#cf5d5d]'],
+html.cyber [class~='border-b-[#cf5d5d]'] {
+  border-right-color: #20964d;
+  border-bottom-color: #20964d;
+}
+html.cyber [class~='hover:bg-[#FF3737]']:hover {
+  background-color: #a1f4bc;
+  color: #03180f;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,8 +25,8 @@ export default {
           950: 'rgb(var(--tw-color-primary-950) / <alpha-value>)',
         },
         dark: '#222222',
-        poidhRed: 'rgb(241, 94, 95)',
-        poidhBlue: '#2a81d5',
+        poidhRed: 'rgb(var(--poidh-red, 241 94 95) / <alpha-value>)',
+        poidhBlue: 'rgb(var(--poidh-blue, 42 129 213) / <alpha-value>)',
       },
       keyframes: {
         flicker: {


### PR DESCRIPTION
Adds a green cyber theme to the existing appearance toggle. The button now cycles through day, night, and cyber modes, saves the selected theme across refreshes, and applies cyber-specific colors to the app, dialogs, navigation, wallet UI, logo, and create-bounty button.

Day and night styling remains unchanged.

Validation:
- TypeScript passed
- Prettier passed
- ESLint passed with existing warnings
- Checked homepage, create-bounty dialog, populated bounty cards, voting, claims, and comments
- Verified theme cycling and persistence
- Verified day/night SVG output remains unchanged